### PR TITLE
[Reviewer: Ellie] Local charms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Overview
+
+This charm supports deployment and scaling of a Project Clearwater system.  See http://www.projectclearwater.org for more information on Project Clearwater.
+
+# Usage
+
+A Clearwater system can be deployed in a Juju environment by creating a config.yaml file then running the following commands.
+
+    git clone https://github.com/Metaswitch/clearwater-juju.git
+    JUJU_REPOSITORY=clearwater-juju/charms juju-deployer -c clearwater-juju/charms/bundles/clearwater/bundle.yaml -c bundle-config.yaml
+
+An example of the bundle-config.yaml configuration file is at [bundle-config.yaml.example](bundle-config.yaml.example).
+
+# Configuration
+
+Clearwater has a number of configuration fields which are non-defaultable.  These are as follows.
+
+clearwater-ellis
+
+-  `signup_key:` This is used as a signup key on the Ellis self-provisioning portal, so should be set to a unique string for each installation.
+-  `base_number:` and `number_count:` These define the telephone number range assigned to the Clearwater system.
+
+# Contact Information
+
+## Upstream Project Name
+
+See http:www.projectclearwater.org and https://github.com/Metaswitch/clearwater-docs/wiki for information about clearwater.
+
+Clearwater source code and issue list can be found at https://github.com/Metaswitch/.
+
+The Clearwater mailing list is at lists.projectclearwater.org.

--- a/README.md
+++ b/README.md
@@ -1,31 +1,28 @@
 # Overview
 
-This charm supports deployment and scaling of a Project Clearwater system.  See http://www.projectclearwater.org for more information on Project Clearwater.
+This repository contains a collection of [Juju charms and deployment bundles](https://jujucharms.com/about), which support deployment and scaling of a [Project Clearwater](http://www.projectclearwater.org) IMS core.
 
 # Usage
 
-A Clearwater system can be deployed in a Juju environment by creating a bundle-config.yaml file then running the following commands:
+Before deploying this charm, you should have bootstrapped a Juju environment, as documented at https://jujucharms.com/docs/stable/getting-started. This charm has been tested on Amazon EC2, with plans to test on OpenStack in the near future - if you get it working on a different cloud service, please let us know!
+
+Clearwater is a reasonably complex system (especially compared to typical beginner Juju examples like Wordpress + MySQL) - deploying a Clearwater IMS core involves deploying and configuring six or seven charms and adding relations between them.
+
+Fortunately, we've set up a Juju bundle that ties all these charms and their relations together, allowing a full system to be deployed in a single step. The bundle contains some default configuration, but additional configuration files can be used to customise the deployment - see [bundle-config.yaml.example](bundle-config.yaml.example) for an example.
+
+A Clearwater system can be deployed in a Juju environment by creating a bundle-config.yaml file then running the following commands.
 
     git clone -b dnsaas https://github.com/Metaswitch/clearwater-juju.git
-    JUJU_REPOSITORY=clearwater-juju/charms juju-deployer -c clearwater-juju/charms/bundles/clearwater/bundle.yaml -c bundle-config.yaml
-
-An example of the bundle-config.yaml configuration file is at [bundle-config.yaml.example](bundle-config.yaml.example).
+    JUJU_REPOSITORY=clearwater-juju/charms juju-deployer -c clearwater-juju/charms/bundles/clearwater/bundles.yaml -c bundle-config.yaml
 
 # Configuration
 
-Clearwater has a number of configuration fields which are non-defaultable.  These are as follows.
+See [bundle-config.yaml.example](bundle-config.yaml.example), which lists the main configuration fields with comments about their meanings.
 
-clearwater-ellis
+# Contact and Upstream Project Information
 
--  `signup_key:` This is used as a signup key on the Ellis self-provisioning portal, so should be set to a unique string for each installation.
--  `base_number:` and `number_count:` These define the telephone number range assigned to the Clearwater system.
+Project Clearwater is an open-source IMS core, developed by [Metaswitch Networks](http://www.metaswitch.com) and released under the [GNU GPLv3](http://www.projectclearwater.org/download/license/). You can find more information about it on [our website](http://www.projectclearwater.org/) or [our documentation site](https://clearwater.readthedocs.org).
 
-# Contact Information
+Clearwater source code and issue trackers can be found at https://github.com/Metaswitch/.
 
-## Upstream Project Name
-
-See http:www.projectclearwater.org and https://github.com/Metaswitch/clearwater-docs/wiki for information about clearwater.
-
-Clearwater source code and issue list can be found at https://github.com/Metaswitch/.
-
-The Clearwater mailing list is at lists.projectclearwater.org.
+If you have problems when using Project Clearwater, read [our troubleshooting documentation](http://clearwater.readthedocs.org/en/latest/Troubleshooting_and_Recovery/index.html) for help, or see [our support page](http://clearwater.readthedocs.org/en/latest/Support/index.html) to find out how to ask mailing list questions or raise issues.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This charm supports deployment and scaling of a Project Clearwater system.  See 
 
 # Usage
 
-A Clearwater system can be deployed in a Juju environment by creating a config.yaml file then running the following commands.
+A Clearwater system can be deployed in a Juju environment by creating a bundle-config.yaml file then running the following commands:
 
-    git clone https://github.com/Metaswitch/clearwater-juju.git
+    git clone -b dnsaas https://github.com/Metaswitch/clearwater-juju.git
     JUJU_REPOSITORY=clearwater-juju/charms juju-deployer -c clearwater-juju/charms/bundles/clearwater/bundle.yaml -c bundle-config.yaml
 
 An example of the bundle-config.yaml configuration file is at [bundle-config.yaml.example](bundle-config.yaml.example).

--- a/bundle-config.yaml.example
+++ b/bundle-config.yaml.example
@@ -1,0 +1,27 @@
+clearwater:
+  services:
+    "clearwater-bono":
+      options:
+        zone: "ims.clearwater.local"
+        trusted_peers: "1.2.3.4,5.6.7.9"
+    "clearwater-sprout":
+      options:
+        zone: "ims.clearwater.local"
+    "clearwater-ralf":
+      options:
+        zone: "ims.clearwater.local"
+    "clearwater-homestead":
+      options:
+        zone: "ims.clearwater.local"
+    "clearwater-homer":
+      options:
+        zone: "ims.clearwater.local"
+    "clearwater-ellis":
+      options:
+        base_number: "1234567000"
+        number_count: 1000
+        signup_key: "abracadabra"
+        zone: "ims.clearwater.local"
+    dns:
+      options:
+        domain: "ims.clearwater.local"

--- a/bundle-config.yaml.example
+++ b/bundle-config.yaml.example
@@ -2,26 +2,62 @@ clearwater:
   services:
     "clearwater-bono":
       options:
+        # Deployment-wide options
+        # These options should be set to the same value for all Clearwater charms
         zone: "ims.clearwater.local"
+        repo: "http://repo.cw-ngv.com/stable"
+        sas: "0.0.0.0"
+
+        # Bono-specific options
+        # trusted_peers  is a comma-separated whitelist of IP addresses. Peers in this list are allowed to send SIP traffic without registration (e.g. for trunking).
         trusted_peers: "1.2.3.4,5.6.7.9"
     "clearwater-sprout":
       options:
+        # Deployment-wide options
+        # These options should be set to the same value for all Clearwater charms
         zone: "ims.clearwater.local"
+        repo: "http://repo.cw-ngv.com/stable"
+        sas: "0.0.0.0"
+
+        # Sprout-specific options
+        # reg_max_expires is the maximum time, in seconds, before a SIP client's registration expires and they have to re-register
+        reg_max_expires: 300
+        # enum is the IP address of an ENUM DNS server, used for translating E.164 numbers like +1-555-123-4567 into SIP URIs. This is optional.
+        enum: "0.0.0.0"
     "clearwater-ralf":
       options:
+        # Deployment-wide options
+        # These options should be set to the same value for all Clearwater charms
         zone: "ims.clearwater.local"
+        repo: "http://repo.cw-ngv.com/stable"
+        sas: "0.0.0.0"
     "clearwater-homestead":
       options:
+        # Deployment-wide options
+        # These options should be set to the same value for all Clearwater charms
         zone: "ims.clearwater.local"
+        repo: "http://repo.cw-ngv.com/stable"
+        sas: "0.0.0.0"
     "clearwater-homer":
       options:
+        # Deployment-wide options
+        # These options should be set to the same value for all Clearwater charms
         zone: "ims.clearwater.local"
+        repo: "http://repo.cw-ngv.com/stable"
     "clearwater-ellis":
       options:
+        # Deployment-wide options
+        # These options should be set to the same value for all Clearwater charms
+        zone: "ims.clearwater.local"
+        repo: "http://repo.cw-ngv.com/stable"
+
+        # Ellis-specific options
+        # Ellis' role is to allocate numbers to users, out of a preconfigured pool. The base_number and number_count settings define that pool - for example, with these values, Ellis could allocate sip:1234567000@ims.clearwater.local to sip:1234567999@ims.clearwater.local.
         base_number: "1234567000"
         number_count: 1000
+        # Ellis allows self-sign-up - anyone who has this signup key can create a user account and multiple lines, so it should be kept secure.
         signup_key: "abracadabra"
-        zone: "ims.clearwater.local"
     dns:
       options:
+        # The dns 'domain' option should match the Clearwater 'zone' option
         domain: "ims.clearwater.local"

--- a/charms/bundles/clearwater/bundle/bundles.yaml
+++ b/charms/bundles/clearwater/bundle/bundles.yaml
@@ -1,7 +1,8 @@
 clearwater:
   services:
     "clearwater-bono":
-      charm: "cs:~matt-williams-x/precise/clearwater-bono"
+      charm: "local:precise/clearwater-bono"
+      charm_url: "local:precise/clearwater-bono"
       num_units: 1
       constraints: "arch=amd64"
       options:
@@ -11,7 +12,8 @@ clearwater:
         "gui-x": "400"
         "gui-y": "900"
     "clearwater-sprout":
-      charm: "cs:~matt-williams-x/precise/clearwater-sprout"
+      charm: "local:precise/clearwater-sprout"
+      charm_url: "local:precise/clearwater-sprout"
       num_units: 1
       constraints: "arch=amd64"
       options:
@@ -20,7 +22,8 @@ clearwater:
         "gui-x": "400"
         "gui-y": "600"
     "clearwater-ralf":
-      charm: "cs:~matt-williams-x/precise/clearwater-ralf"
+      charm: "local:precise/clearwater-ralf"
+      charm_url: "local:precise/clearwater-ralf"
       num_units: 1
       constraints: "arch=amd64"
       options:
@@ -29,7 +32,8 @@ clearwater:
         "gui-x": "800"
         "gui-y": "750"
     "clearwater-homestead":
-      charm: "cs:~matt-williams-x/precise/clearwater-homestead"
+      charm: "local:precise/clearwater-homestead"
+      charm_url: "local:precise/clearwater-homestead"
       num_units: 1
       constraints: "arch=amd64"
       options:
@@ -38,7 +42,8 @@ clearwater:
         "gui-x": "200"
         "gui-y": "300"
     "clearwater-homer":
-      charm: "cs:~matt-williams-x/precise/clearwater-homer"
+      charm: "local:precise/clearwater-homer"
+      charm_url: "local:precise/clearwater-homer"
       num_units: 1
       constraints: "arch=amd64"
       options:
@@ -47,7 +52,8 @@ clearwater:
         "gui-x": "600"
         "gui-y": "300"
     "clearwater-ellis":
-      charm: "cs:~matt-williams-x/precise/clearwater-ellis"
+      charm: "local:precise/clearwater-ellis"
+      charm_url: "local:precise/clearwater-ellis"
       num_units: 1
       constraints: "arch=amd64"
       options:


### PR DESCRIPTION
This pull request changes our bundle so that it points at locally-checked-out charms, not the Launchpad-hosted ones. This means that:
- Github is now the master/sole home of our charms - there's no need to recommit fixes in bzr and push them to Launchpad
- it's a bit easier to change/deploy/test the charms, because you always deploy from your local checkout

I've also included examples of how to customize your deployment (e.g. number ranges, domain, trusted peers) when you deploy from the bundle.

I checked on the Juju mailing list that this is the right way to do it when you have one Github repository containing several charms - see the thread starting at https://lists.ubuntu.com/archives/juju/2015-April/005211.html.

Tested by deploying the bundle, creating a subscriber in Ellis, and registering them (though I needed some DNS-charm-related changes which I'm about to send).
