### PR TITLE
[Reviewer: Ellie] Always use the Birdsong code for charms

### DIFF
--- a/charms/precise/clearwater-bono/config.yaml
+++ b/charms/precise/clearwater-bono/config.yaml
@@ -15,6 +15,6 @@ options:
     description: Comma-separated list of IP addresses of trusted peers
     type: string
   repo:
-    default: http://repo.cw-ngv.com/stable
+    default: http://repo.cw-ngv.com/archive/repo70
     description: The location of the repo server
     type: string

--- a/charms/precise/clearwater-bono/lib/chef_solo_install
+++ b/charms/precise/clearwater-bono/lib/chef_solo_install
@@ -13,12 +13,12 @@ bash <(wget  ${install_sh} -O -) ${version_string}
 if [ ! -d /home/ubuntu/chef-solo ]
 then
   mkdir /home/ubuntu/chef-solo
-  git clone --recursive -b master git://github.com/Metaswitch/chef.git /home/ubuntu/chef-solo
+  git clone --recursive -b release-69 git://github.com/Metaswitch/chef.git /home/ubuntu/chef-solo
 fi
 
 # Update the chef recipes
 cd /home/ubuntu/chef-solo
-git pull origin --recurse-submodules master
+git pull origin --recurse-submodules release-69
 
 # Create the solo.rb file
 cat > /home/ubuntu/chef-solo/solo.rb <<EOP

--- a/charms/precise/clearwater-ellis/config.yaml
+++ b/charms/precise/clearwater-ellis/config.yaml
@@ -29,6 +29,6 @@ options:
     description: The count of numbers to allocate
     type: int
   repo:
-    default: http://repo.cw-ngv.com/stable
+    default: http://repo.cw-ngv.com/archive/repo70
     description: The location of the repo server
     type: string

--- a/charms/precise/clearwater-ellis/lib/chef_solo_install
+++ b/charms/precise/clearwater-ellis/lib/chef_solo_install
@@ -13,12 +13,12 @@ bash <(wget  ${install_sh} -O -) ${version_string}
 if [ ! -d /home/ubuntu/chef-solo ]
 then
   mkdir /home/ubuntu/chef-solo
-  git clone --recursive -b master git://github.com/Metaswitch/chef.git /home/ubuntu/chef-solo
+  git clone --recursive -b release-69 git://github.com/Metaswitch/chef.git /home/ubuntu/chef-solo
 fi
 
 # Update the chef recipes
 cd /home/ubuntu/chef-solo
-git pull origin --recurse-submodules master
+git pull origin --recurse-submodules release-69
 
 # Create the solo.rb file
 cat > /home/ubuntu/chef-solo/solo.rb <<EOP

--- a/charms/precise/clearwater-homer/config.yaml
+++ b/charms/precise/clearwater-homer/config.yaml
@@ -3,6 +3,6 @@ options:
     description: The DNS root zone for this service
     type: string
   repo:
-    default: http://repo.cw-ngv.com/stable
+    default: http://repo.cw-ngv.com/archive/repo70
     description: The location of the repo server
     type: string

--- a/charms/precise/clearwater-homer/lib/chef_solo_install
+++ b/charms/precise/clearwater-homer/lib/chef_solo_install
@@ -13,12 +13,12 @@ bash <(wget  ${install_sh} -O -) ${version_string}
 if [ ! -d /home/ubuntu/chef-solo ]
 then
   mkdir /home/ubuntu/chef-solo
-  git clone --recursive -b master git://github.com/Metaswitch/chef.git /home/ubuntu/chef-solo
+  git clone --recursive -b release-69 git://github.com/Metaswitch/chef.git /home/ubuntu/chef-solo
 fi
 
 # Update the chef recipes
 cd /home/ubuntu/chef-solo
-git pull origin --recurse-submodules master
+git pull origin --recurse-submodules release-69
 
 # Create the solo.rb file
 cat > /home/ubuntu/chef-solo/solo.rb <<EOP

--- a/charms/precise/clearwater-homestead/config.yaml
+++ b/charms/precise/clearwater-homestead/config.yaml
@@ -7,6 +7,6 @@ options:
     description: The location of the SAS server
     type: string
   repo:
-    default: http://repo.cw-ngv.com/stable
+    default: http://repo.cw-ngv.com/archive/repo70
     description: The location of the repo server
     type: string

--- a/charms/precise/clearwater-homestead/lib/chef_solo_install
+++ b/charms/precise/clearwater-homestead/lib/chef_solo_install
@@ -13,12 +13,12 @@ bash <(wget  ${install_sh} -O -) ${version_string}
 if [ ! -d /home/ubuntu/chef-solo ]
 then
   mkdir /home/ubuntu/chef-solo
-  git clone --recursive -b master git://github.com/Metaswitch/chef.git /home/ubuntu/chef-solo
+  git clone --recursive -b release-69 git://github.com/Metaswitch/chef.git /home/ubuntu/chef-solo
 fi
 
 # Update the chef recipes
 cd /home/ubuntu/chef-solo
-git pull origin --recurse-submodules master
+git pull origin --recurse-submodules release-69
 
 # Create the solo.rb file
 cat > /home/ubuntu/chef-solo/solo.rb <<EOP

--- a/charms/precise/clearwater-ralf/config.yaml
+++ b/charms/precise/clearwater-ralf/config.yaml
@@ -7,6 +7,6 @@ options:
     description: The location of the SAS server
     type: string
   repo:
-    default: http://repo.cw-ngv.com/stable
+    default: http://repo.cw-ngv.com/archive/repo70
     description: The location of the repo server
     type: string

--- a/charms/precise/clearwater-ralf/lib/chef_solo_install
+++ b/charms/precise/clearwater-ralf/lib/chef_solo_install
@@ -13,12 +13,12 @@ bash <(wget  ${install_sh} -O -) ${version_string}
 if [ ! -d /home/ubuntu/chef-solo ]
 then
   mkdir /home/ubuntu/chef-solo
-  git clone --recursive -b master git://github.com/Metaswitch/chef.git /home/ubuntu/chef-solo
+  git clone --recursive -b release-69 git://github.com/Metaswitch/chef.git /home/ubuntu/chef-solo
 fi
 
 # Update the chef recipes
 cd /home/ubuntu/chef-solo
-git pull origin --recurse-submodules master
+git pull origin --recurse-submodules release-69
 
 # Create the solo.rb file
 cat > /home/ubuntu/chef-solo/solo.rb <<EOP

--- a/charms/precise/clearwater-sprout/config.yaml
+++ b/charms/precise/clearwater-sprout/config.yaml
@@ -19,6 +19,6 @@ options:
     description: Maximum session expiry time (sec)
     type: int
   repo:
-    default: http://repo.cw-ngv.com/stable
+    default: http://repo.cw-ngv.com/archive/repo70
     description: The location of the repo server
     type: string

--- a/charms/precise/clearwater-sprout/lib/chef_solo_install
+++ b/charms/precise/clearwater-sprout/lib/chef_solo_install
@@ -14,12 +14,12 @@ bash <(wget  ${install_sh} -O -) ${version_string}
 if [ ! -d /home/ubuntu/chef-solo ]
 then
   mkdir /home/ubuntu/chef-solo
-  git clone --recursive -b master git://github.com/Metaswitch/chef.git /home/ubuntu/chef-solo
+  git clone --recursive -b release-69 git://github.com/Metaswitch/chef.git /home/ubuntu/chef-solo
 fi
 
 # Update the chef recipes
 cd /home/ubuntu/chef-solo
-git pull origin --recurse-submodules master
+git pull origin --recurse-submodules release-69
 
 # Create the solo.rb file
 cat > /home/ubuntu/chef-solo/solo.rb <<EOP


### PR DESCRIPTION
This fix uses the Birdsong-release .deb files and Chef code when deploying Juju charms - hopefully, this should make the charms more stable (because if we make an orchestration-breaking code change and don't update the charms, the charms won't pick up the new version until we explicitly test it and update it).

Tested by spinning up a deployment, checking there were no errors, and that I could access Ellis over HTTP (but I didn't create or register a line).
