### PR TITLE
[Reviewer: Ellie] Clean up the clearwater-bono charm

### DIFF
--- a/charms/bundles/clearwater/bundle/bundles.yaml
+++ b/charms/bundles/clearwater/bundle/bundles.yaml
@@ -74,10 +74,6 @@ clearwater:
         "gui-x": "1000"
         "gui-y": "450"
   relations:
-    - - "clearwater-bono:scscf"
-      - "clearwater-sprout:pcscf"
-    - - "clearwater-bono:ralf-ctf"
-      - "clearwater-ralf:ralf-cscf"
     - - "clearwater-sprout:ralf-ctf"
       - "clearwater-ralf:ralf-cscf"
     - - "clearwater-homestead:homestead-cscf"

--- a/charms/precise/clearwater-bono/README.md
+++ b/charms/precise/clearwater-bono/README.md
@@ -1,6 +1,6 @@
 # Overview
 
-This is a [Juju charm](https://jujucharms.com/about), which allows deployment and scaling of the Bono component of a [Project Clearwater](http://projectclearwater.org) IMS core.
+This is a [Juju charm](https://jujucharms.com/about), which allows deployment and scaling of the [Bono](https://github.com/Metaswitch/sprout/#sprout-and-bono) component of a [Project Clearwater](http://projectclearwater.org) IMS core.
 
 Bono should only be deployed alongside the other Project Clearwater charms and a DNS server - see [our main Juju README](https://github.com/Metaswitch/clearwater-juju/blob/local_charms/README.md) for instructions on this, including a bundle that makes this deployment simple.
 
@@ -16,7 +16,7 @@ Note that the clearwater-bono charm can only be deployed on the `amd64` architec
 
 clearwater-bono can be scaled up through the normal Juju mechanism of `juju add-unit clearwater-bono`.
 
-This will create a new Bono instance, and trigger the DNS server charm to add a DNS record for this Bono. (Unlike Sprout, Homestead and Homer nodes, Bono nodes don't have a shared datastore, so don't need any cluster configuration.)
+This will create a new Bono instance, and trigger the DNS server charm to add a DNS record for this Bono. (Unlike Sprout, Homestead, Homer and Ralf nodes, Bono nodes don't have a shared datastore, so don't need any cluster configuration.)
 
 # Using Bono
 
@@ -45,6 +45,6 @@ When the charm is being installed, several files are downloaded:
 
 Project Clearwater is an open-source IMS core, developed by [Metaswitch Networks](http://www.metaswitch.com) and released under the [GNU GPLv3](http://www.projectclearwater.org/download/license/). You can find more information about it on [our website](http://www.projectclearwater.org/) or [our documentation site](https://clearwater.readthedocs.org).
 
-Clearwater source code and issue list can be found at https://github.com/Metaswitch/.
+Clearwater source code and issue list can be found at https://github.com/Metaswitch/. Bono's source code can be found at https://github.com/Metaswitch/sprout/.
 
 If you have problems when using Project Clearwater, read [our troubleshooting documentation](http://clearwater.readthedocs.org/en/latest/Troubleshooting_and_Recovery/index.html) for help, or see [our support page](http://clearwater.readthedocs.org/en/latest/Support/index.html) to find out how to ask mailing list questions or raise issues.

--- a/charms/precise/clearwater-bono/config.yaml
+++ b/charms/precise/clearwater-bono/config.yaml
@@ -1,5 +1,6 @@
 options:
   zone:
+    default: "clearwater.local"
     description: The DNS root zone for this service
     type: string
   sas:

--- a/charms/precise/clearwater-bono/hooks/ralf-ctf-relation-changed
+++ b/charms/precise/clearwater-bono/hooks/ralf-ctf-relation-changed
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -e
-
-# Update Clearwater configuration and restart
-$CHARM_DIR/lib/config_script ralf-ctf
-$CHARM_DIR/lib/restart

--- a/charms/precise/clearwater-bono/hooks/scscf-relation-changed
+++ b/charms/precise/clearwater-bono/hooks/scscf-relation-changed
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -e
-
-# Update Clearwater configuration and restart
-$CHARM_DIR/lib/config_script scscf
-$CHARM_DIR/lib/restart

--- a/charms/precise/clearwater-bono/lib/config_script
+++ b/charms/precise/clearwater-bono/lib/config_script
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-relation_name=$1
-
 set -e
 
 # Defaults
@@ -17,8 +15,6 @@ enum_server=
 
 # Apply new configuration
 home_domain=$(config-get zone)
-[ "$relation-name" != "scscf" ] || [ "$(relation-get public-address)" = "" ] || sprout_hostname=$(relation-get public-address)
-[ "$relation-name" != "ralf-ctf" ] || [ "$(relation-get public-address)" = "" ] || ralf_hostname=$(relation-get public-address):9888
 sas_server=$(config-get sas)
 local_ip=$(unit-get private-address)
 public_ip=$(unit-get public-address)

--- a/charms/precise/clearwater-bono/metadata.yaml
+++ b/charms/precise/clearwater-bono/metadata.yaml
@@ -2,14 +2,9 @@ name: clearwater-bono
 summary: Bono charm for Project Clearwater
 maintainer: Project Clearwater Maintainers <maintainers@projectclearwater.org>
 description: Bono charm for Project Clearwater
-categories:
+tags:
   - misc
 subordinate: false
 requires:
   programmable-multiple:
     interface: dns-multi
-  scscf:
-    interface: 3GPP-Mr
-  ralf-ctf:
-    interface: ralf-ctf-interface
-    optional: true


### PR DESCRIPTION
Yet another Juju review for you (but this is nearly the last one!).

This cleans up the Bono charm in advance of submitting it for charm review. I've:
- substantially rewritten the README, including documenting scaling - it should now pass https://jujucharms.com/docs/stable/charm-review-process#reading-the-readme
- realised that we don't need the relations with Sprout or Ralf (we used those to learn an IP address, but now we have DNS names instead, which is necessary for multiple Sprouts) so removed that code
- changed "categories" to "tags" based on a 'charm proof' warning message

`charm proof` now outputs no errors or warnings (but one info-level message, which is OK).

I've tested by creating a deployment, registering a subscriber through clearwater-bono/0, running `juju add-unit clearwater-bono`, checking that I could register through either Bono node, and checking that `_sip._tcp.ims.clearwater.local` resolved to both hosts.
