### PR TITLE
[Reviewer: Rob] Close TCP port 6666 - 0MQ is not longer exposed on this port

### DIFF
--- a/charms/precise/clearwater-bono/hooks/install
+++ b/charms/precise/clearwater-bono/hooks/install
@@ -25,4 +25,3 @@ open-port 3478/udp
 open-port 5060/tcp
 open-port 5060/udp
 open-port 5062/tcp
-open-port 6666/tcp

--- a/charms/precise/clearwater-sprout/hooks/install
+++ b/charms/precise/clearwater-sprout/hooks/install
@@ -26,4 +26,3 @@ chef-solo -c /home/ubuntu/chef-solo/solo.rb -j /home/ubuntu/chef-solo/node.json
 open-port 22/tcp
 open-port 123/udp
 open-port 161/udp
-open-port 6666/tcp


### PR DESCRIPTION
Rob,

Our Juju charms still exposed port 6666 (0MQ).  Since we no longer expose that, we should close it.

Matt
