### PR TITLE
[Reviewer: Rob] Correct DNS charm version in Restcomm bundle

### DIFF
--- a/charms/bundles/clearwater-restcomm/bundle/bundles.yaml
+++ b/charms/bundles/clearwater-restcomm/bundle/bundles.yaml
@@ -60,7 +60,7 @@ clearwater:
         "gui-x": "400"
         "gui-y": "0"
     dns: 
-      charm: "cs:~lazypower/precise/dns-1"
+      charm: "cs:~lazypower/precise/dns-3"
       num_units: 1
       options: 
         domain: "clearwater.local"


### PR DESCRIPTION
Rob,

Minor fix just to bring Restcomm bundle's DNS charm version into line with solo Clearwater bundle.

Matt
