### PR TITLE
[Reviewer: Rob] Wait for DNS to recover after installing dnsmasq before installing anything else

### DIFF
--- a/charms/precise/clearwater-bono/hooks/install
+++ b/charms/precise/clearwater-bono/hooks/install
@@ -13,6 +13,16 @@ $CHARM_DIR/lib/config_script
 
 apt-get update
 
+# After we install dnsmasq, DNS might drop for a few seconds.  Install it ahead of time
+# and wait for DNS to recover.
+apt-get -q -y --force-yes install dnsmasq
+iterations=0
+while [ $(dig +short security.ubuntu.com | wc -l) == 0 ] && [ $iterations -lt 60 ] ; do
+  echo "Waiting for DNS to security.ubuntu.com to recover ($iterations/60)..."
+  sleep 1
+  iterations=$((iterations + 1))
+done
+
 # Install the node
 chef-solo -c /home/ubuntu/chef-solo/solo.rb -j /home/ubuntu/chef-solo/node.json
 

--- a/charms/precise/clearwater-ellis/hooks/install
+++ b/charms/precise/clearwater-ellis/hooks/install
@@ -12,6 +12,16 @@ $CHARM_DIR/lib/config_script
 
 apt-get update
 
+# After we install dnsmasq, DNS might drop for a few seconds.  Install it ahead of time
+# and wait for DNS to recover.
+apt-get -q -y --force-yes install dnsmasq
+iterations=0
+while [ $(dig +short security.ubuntu.com | wc -l) == 0 ] && [ $iterations -lt 60 ] ; do
+  echo "Waiting for DNS to security.ubuntu.com to recover ($iterations/60)..."
+  sleep 1
+  iterations=$((iterations + 1))
+done
+
 # Install the node
 chef-solo -c /home/ubuntu/chef-solo/solo.rb -j /home/ubuntu/chef-solo/node.json
 

--- a/charms/precise/clearwater-homer/hooks/install
+++ b/charms/precise/clearwater-homer/hooks/install
@@ -22,6 +22,16 @@ $CHARM_DIR/lib/config_script
 
 apt-get update
 
+# After we install dnsmasq, DNS might drop for a few seconds.  Install it ahead of time
+# and wait for DNS to recover.
+apt-get -q -y --force-yes install dnsmasq
+iterations=0
+while [ $(dig +short security.ubuntu.com | wc -l) == 0 ] && [ $iterations -lt 60 ] ; do
+  echo "Waiting for DNS to security.ubuntu.com to recover ($iterations/60)..."
+  sleep 1
+  iterations=$((iterations + 1))
+done
+
 # Install the node
 chef-solo -c /home/ubuntu/chef-solo/solo.rb -j /home/ubuntu/chef-solo/node.json
 

--- a/charms/precise/clearwater-homestead/hooks/install
+++ b/charms/precise/clearwater-homestead/hooks/install
@@ -19,6 +19,16 @@ $CHARM_DIR/lib/config_script
 
 apt-get update
 
+# After we install dnsmasq, DNS might drop for a few seconds.  Install it ahead of time
+# and wait for DNS to recover.
+apt-get -q -y --force-yes install dnsmasq
+iterations=0
+while [ $(dig +short security.ubuntu.com | wc -l) == 0 ] && [ $iterations -lt 60 ] ; do
+  echo "Waiting for DNS to security.ubuntu.com to recover ($iterations/60)..."
+  sleep 1
+  iterations=$((iterations + 1))
+done
+
 # Install the node
 chef-solo -c /home/ubuntu/chef-solo/solo.rb -j /home/ubuntu/chef-solo/node.json
 

--- a/charms/precise/clearwater-ralf/hooks/install
+++ b/charms/precise/clearwater-ralf/hooks/install
@@ -19,6 +19,16 @@ $CHARM_DIR/lib/config_script
 
 apt-get update
 
+# After we install dnsmasq, DNS might drop for a few seconds.  Install it ahead of time
+# and wait for DNS to recover.
+apt-get -q -y --force-yes install dnsmasq
+iterations=0
+while [ $(dig +short security.ubuntu.com | wc -l) == 0 ] && [ $iterations -lt 60 ] ; do
+  echo "Waiting for DNS to security.ubuntu.com to recover ($iterations/60)..."
+  sleep 1
+  iterations=$((iterations + 1))
+done
+
 # Install the node
 chef-solo -c /home/ubuntu/chef-solo/solo.rb -j /home/ubuntu/chef-solo/node.json
 

--- a/charms/precise/clearwater-sprout/hooks/install
+++ b/charms/precise/clearwater-sprout/hooks/install
@@ -19,6 +19,16 @@ $CHARM_DIR/lib/config_script
 
 apt-get update
 
+# After we install dnsmasq, DNS might drop for a few seconds.  Install it ahead of time
+# and wait for DNS to recover.
+apt-get -q -y --force-yes install dnsmasq
+iterations=0
+while [ $(dig +short security.ubuntu.com | wc -l) == 0 ] && [ $iterations -lt 60 ] ; do
+  echo "Waiting for DNS to security.ubuntu.com to recover ($iterations/60)..."
+  sleep 1
+  iterations=$((iterations + 1))
+done
+
 # Install the node
 chef-solo -c /home/ubuntu/chef-solo/solo.rb -j /home/ubuntu/chef-solo/node.json
 


### PR DESCRIPTION
Rob,

As discussed, my Juju installs were intermittently failing because, after installing dnsmasq, DNS could take a few seconds to recover.  My fix is to install dnsmasq up front and then wait to get a response again before proceeding with the rest of the install.  security.ubuntu.com is guaranteed to be required for the install (as some of the packages we install are secure, and security.ubuntu.com is not proxied).

Matt
