### PR TITLE
[Reviewer: Rob] Interface tweaks

### DIFF
--- a/charms/bundles/clearwater-restcomm/bundle/bundles.yaml
+++ b/charms/bundles/clearwater-restcomm/bundle/bundles.yaml
@@ -89,7 +89,7 @@ clearwater:
         "gui-x": "-1000"
         "gui-y": "300"
   relations: 
-    - - "clearwater-bono:scscf"
+    - - "clearwater-bono:cscf"
       - "clearwater-sprout:pcscf"
     - - "clearwater-bono:ralf-ctf"
       - "clearwater-ralf:ralf-cscf"

--- a/charms/bundles/clearwater/bundle/bundles.yaml
+++ b/charms/bundles/clearwater/bundle/bundles.yaml
@@ -74,6 +74,10 @@ clearwater:
         "gui-x": "1000"
         "gui-y": "450"
   relations:
+    - - "clearwater-bono:cscf"
+      - "clearwater-sprout:pcscf"
+    - - "clearwater-bono:ralf-ctf"
+      - "clearwater-ralf:ralf-cscf"
     - - "clearwater-sprout:ralf-ctf"
       - "clearwater-ralf:ralf-cscf"
     - - "clearwater-homestead:homestead-cscf"

--- a/charms/precise/clearwater-bono/hooks/cscf-relation-changed
+++ b/charms/precise/clearwater-bono/hooks/cscf-relation-changed
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
-# Update Clearwater configuration and restart
+# Update Clearwater configuration and restart if anything changed
+cp /etc/clearwater/config /tmp/config.$$
 $CHARM_DIR/lib/config_script cscf
-$CHARM_DIR/lib/restart
+cmp /etc/clearwater/config /tmp/config.$$ || $CHARM_DIR/lib/restart
+rm -f /tmp/config.$$

--- a/charms/precise/clearwater-bono/hooks/cscf-relation-changed
+++ b/charms/precise/clearwater-bono/hooks/cscf-relation-changed
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# Update Clearwater configuration and restart
+$CHARM_DIR/lib/config_script cscf
+$CHARM_DIR/lib/restart

--- a/charms/precise/clearwater-bono/hooks/ralf-ctf-relation-changed
+++ b/charms/precise/clearwater-bono/hooks/ralf-ctf-relation-changed
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# Update Clearwater configuration and restart
+$CHARM_DIR/lib/config_script ralf-ctf
+$CHARM_DIR/lib/restart

--- a/charms/precise/clearwater-bono/hooks/ue-relation-joined
+++ b/charms/precise/clearwater-bono/hooks/ue-relation-joined
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+relation-set public-address=$(config-get zone)

--- a/charms/precise/clearwater-bono/lib/config_script
+++ b/charms/precise/clearwater-bono/lib/config_script
@@ -15,6 +15,8 @@ enum_server=
 
 # Apply new configuration
 home_domain=$(config-get zone)
+[ "$relation-name" != "cscf" ] || [ "$(relation-get public-address)" = "" ] || sprout_hostname=$(relation-get public-address)
+[ "$relation-name" != "ralf-ctf" ] || [ "$(relation-get public-address)" = "" ] || ralf_hostname=$(relation-get public-address):9888
 sas_server=$(config-get sas)
 local_ip=$(unit-get private-address)
 public_ip=$(unit-get public-address)

--- a/charms/precise/clearwater-bono/metadata.yaml
+++ b/charms/precise/clearwater-bono/metadata.yaml
@@ -5,6 +5,14 @@ description: Bono charm for Project Clearwater
 tags:
   - misc
 subordinate: false
+provides:
+  ue:
+    interface: 3GPP-Gm
 requires:
+  cscf:
+    interface: 3GPP-Mw
+  ralf-ctf:
+    interface: ralf-ctf-interface
+    optional: true
   programmable-multiple:
     interface: dns-multi

--- a/charms/precise/clearwater-sprout/metadata.yaml
+++ b/charms/precise/clearwater-sprout/metadata.yaml
@@ -21,7 +21,7 @@ requires:
     optional: true
 provides:
   pcscf:
-    interface: 3GPP-Mr
+    interface: 3GPP-Mw
 peers:
   sprout:
     interface: sprout-interface


### PR DESCRIPTION
Rob,

Please can you review these tweaks to Juju interfaces that I spotted while testing?
-   The Bono/Sprout interface is Mw, not Mr.
-   The Bono/Sprout interface was misconfigured in the restcomm bundle and not configured at all in the vanilla Clearwater bundle.
-   Bono didn't actually pay any attention to the Sprout or Ralf interfaces - it didn't change its configuration.
-   Bono didn't officially expose a UE interface.

Thanks,

Matt
