### PR TITLE
[Reviewer: Rob] Handle init restarting clearwater-monit

### DIFF
--- a/charms/precise/clearwater-bono/hooks/start
+++ b/charms/precise/clearwater-bono/hooks/start
@@ -7,10 +7,11 @@ set -e
 # This hook needs to be idempotent, so this could be run when bono is
 # already running, when it's running but not monitored by monit, when
 # it's stopped but being monitored (so it's about to start), or stopped
-# and unmonitored. To cover all these cases, stop monit, start bono, start
-# monit, then finally have monit monitor bono
-service clearwater-monit stop
-service bono start
-service clearwater-monit start
+# and unmonitored. To cover all these cases, restart bono, restart monit,
+# then finally have monit monitor bono.  Note that restarting monit can
+# fail because init will also restart it when it stops and restarting
+# bono can fail because monit will restart it.
+service bono restart || /usr/bin/true
+service clearwater-monit restart || /usr/bin/true
 sleep 1
 monit monitor bono

--- a/charms/precise/clearwater-ellis/hooks/start
+++ b/charms/precise/clearwater-ellis/hooks/start
@@ -7,10 +7,11 @@ set -e
 # This hook needs to be idempotent, so this could be run when ellis is
 # already running, when it's running but not monitored by monit, when
 # it's stopped but being monitored (so it's about to start), or stopped
-# and unmonitored. To cover all these cases, stop monit, start ellis, start
-# monit, then finally have monit monitor ellis
-service clearwater-monit stop
-service ellis start
-service clearwater-monit start
+# and unmonitored. To cover all these cases, restart ellis, restart monit,
+# then finally have monit monitor ellis.  Note that restarting monit can
+# fail because init will also restart it when it stops and restarting
+# ellis can fail because monit will restart it.
+service ellis restart || /usr/bin/true
+service clearwater-monit restart || /usr/bin/true
 sleep 1
 monit monitor ellis

--- a/charms/precise/clearwater-homer/hooks/start
+++ b/charms/precise/clearwater-homer/hooks/start
@@ -7,10 +7,11 @@ set -e
 # This hook needs to be idempotent, so this could be run when homer is
 # already running, when it's running but not monitored by monit, when
 # it's stopped but being monitored (so it's about to start), or stopped
-# and unmonitored. To cover all these cases, stop monit, start homer, start
-# monit, then finally have monit monitor homer
-service clearwater-monit stop
-service homer start
-service clearwater-monit start
+# and unmonitored. To cover all these cases, restart homer, restart monit,
+# then finally have monit monitor homer Note that restarting monit can
+# fail because init will also restart it when it stops and restarting
+# homert can fail because monit will restart it.
+service homer restart || /usr/bin/true
+service clearwater-monit restart || /usr/bin/true
 sleep 1
 monit monitor homer

--- a/charms/precise/clearwater-homestead/hooks/start
+++ b/charms/precise/clearwater-homestead/hooks/start
@@ -7,12 +7,13 @@ set -e
 # This hook needs to be idempotent, so this could be run when homestead is
 # already running, when it's running but not monitored by monit, when
 # it's stopped but being monitored (so it's about to start), or stopped
-# and unmonitored. To cover all these cases, stop monit, start homestead, start
-# monit, then finally have monit monitor homestead
-service clearwater-monit stop
-service homestead start
-service homestead-prov start
-service clearwater-monit start
+# and unmonitored. To cover all these cases, restart homestead, restart monit,
+# then finally have monit monitor homestead.  Note that restarting monit can
+# fail because init will also restart it when it stops and restarting
+# homestead can fail because monit will restart it.
+service homestead restart || /usr/bin/true
+service homestead-prov restart || /usr/bin/true
+service clearwater-monit restart || /usr/bin/true
 sleep 1
 monit monitor homestead
 monit monitor homestead-prov

--- a/charms/precise/clearwater-ralf/hooks/start
+++ b/charms/precise/clearwater-ralf/hooks/start
@@ -7,10 +7,11 @@ set -e
 # This hook needs to be idempotent, so this could be run when ralf is
 # already running, when it's running but not monitored by monit, when
 # it's stopped but being monitored (so it's about to start), or stopped
-# and unmonitored. To cover all these cases, stop monit, start ralf, start
-# monit, then finally have monit monitor ralf
-service clearwater-monit stop
-service ralf start
-service clearwater-monit start
+# and unmonitored. To cover all these cases, restart ralf, restart monit,
+# then finally have monit monitor ralf.  Note that restarting monit can
+# fail because init will also restart it when it stops and restarting
+# ralf can fail because monit will restart it.
+service ralf restart || /usr/bin/true
+service clearwater-monit restart || /usr/bin/true
 sleep 1
 monit monitor ralf

--- a/charms/precise/clearwater-sprout/hooks/start
+++ b/charms/precise/clearwater-sprout/hooks/start
@@ -7,10 +7,11 @@ set -e
 # This hook needs to be idempotent, so this could be run when sprout is
 # already running, when it's running but not monitored by monit, when
 # it's stopped but being monitored (so it's about to start), or stopped
-# and unmonitored. To cover all these cases, stop monit, start sprout, start
-# monit, then finally have monit monitor sprout
-service clearwater-monit stop
-service sprout start
-service clearwater-monit start
+# and unmonitored. To cover all these cases, restart sprout, restart monit,
+# then finally have monit monitor sprout.  Note that restarting monit can
+# fail because init will also restart it when it stops and restarting
+# sprout can fail because monit will restart it.
+service sprout restart || /usr/bin/true
+service clearwater-monit restart || /usr/bin/true
 sleep 1
 monit monitor sprout


### PR DESCRIPTION
We recently moved clearwater-monit to be restarted by init.  This means that `clearwater-monit start` might fail because init has restarted in the meantime.

Instead, we try to restart the process, then restart monit and ignore error codes in either case (as the process could have already been started).
