### PR TITLE
[Reviewer: Ellie] Apply feedback from charm review

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/clearwater-live-test"]
+	path = tests/clearwater-live-test
+	url = https://github.com/Metaswitch/clearwater-live-test.git

--- a/README.md
+++ b/README.md
@@ -13,11 +13,20 @@ Fortunately, we've set up a Juju bundle that ties all these charms and their rel
 A Clearwater system can be deployed in a Juju environment by creating a bundle-config.yaml file then running the following commands.
 
     git clone -b dnsaas https://github.com/Metaswitch/clearwater-juju.git
-    JUJU_REPOSITORY=clearwater-juju/charms juju-deployer -c clearwater-juju/charms/bundles/clearwater/bundle/bundles.yaml -c bundle-config.yaml
+    cd clearwater-juju
+    JUJU_REPOSITORY=charms juju-deployer -c charms/bundles/clearwater/bundle/bundles.yaml -c bundle-config.yaml
 
 # Configuration
 
 See [bundle-config.yaml.example](bundle-config.yaml.example), which lists the main configuration fields with comments about their meanings.
+
+# Testing
+
+This repository contains Amulet tests for automated testing. To run them, use:
+
+    git clone -b dnsaas https://github.com/Metaswitch/clearwater-juju.git
+    cd clearwater-juju
+    JUJU_REPOSITORY=charms juju test -o logs -v -p JUJU_REPOSITORY,HOME --timeout=1200s
 
 # Contact and Upstream Project Information
 

--- a/charms/precise/clearwater-bono/hooks/upgrade-charm
+++ b/charms/precise/clearwater-bono/hooks/upgrade-charm
@@ -1,9 +1,8 @@
 #!/bin/bash
 # This hook is executed each time a charm is upgraded after the new charm
 # contents have been unpacked
-# Best practice suggests you execute the hooks/install and
-# hooks/config-changed to ensure all updates are processed
+# Best practice suggests you execute the hooks/install to ensure all updates are processed -
+# hooks/config_change is triggered automatically
 set -e
 
 $CHARM_DIR/hooks/install
-$CHARM_DIR/hooks/config-changed

--- a/charms/precise/clearwater-bono/lib/chef-install.sh
+++ b/charms/precise/clearwater-bono/lib/chef-install.sh
@@ -1,0 +1,601 @@
+#!/bin/sh
+# WARNING: REQUIRES /bin/sh
+#
+# - must run on /bin/sh on solaris 9
+# - must run on /bin/sh on AIX 6.x
+# - if you think you are a bash wizard, you probably do not understand
+#   this programming language.  do not touch.
+# - if you are under 40, get peer review from your elders.
+#
+# Author:: Tyler Cloke (tyler@opscode.com)
+# Author:: Stephen Delano (stephen@opscode.com)
+# Author:: Seth Chisamore (sethc@opscode.com)
+# Author:: Lamont Granquist (lamont@opscode.com)
+# Copyright:: Copyright (c) 2010-2013 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+prerelease="false"
+
+nightlies="false"
+
+project="chef"
+
+# Check whether a command exists - returns 0 if it does, 1 if it does not
+exists() {
+  if command -v $1 >/dev/null 2>&1
+  then
+    return 0
+  else
+    return 1
+  fi
+}
+
+report_bug() {
+  echo "Version: $version"
+  echo ""
+  echo "Please file a Bug Report at https://github.com/opscode/opscode-omnitruck/issues/new"
+  echo "Alternatively, feel free to open a Support Ticket at https://www.getchef.com/support/tickets"
+  echo "More Chef support resources can be found at https://www.getchef.com/support"
+  echo ""
+  echo "Please include as many details about the problem as possible i.e., how to reproduce"
+  echo "the problem (if possible), type of the Operating System and its version, etc.,"
+  echo "and any other relevant details that might help us with troubleshooting."
+  echo ""
+}
+
+# Get command line arguments
+while getopts pnv:f:d:P: opt
+do
+  case "$opt" in
+
+    v)  version="$OPTARG";;
+    p)  prerelease="true";;
+    n)  nightlies="true";;
+    f)  cmdline_filename="$OPTARG";;
+    P)  project="$OPTARG";;
+    d)  cmdline_dl_dir="$OPTARG";;
+    \?)   # unknown flag
+      echo >&2 \
+      "usage: $0 [-p] [-v version] [-f filename | -d download_dir]"
+      exit 1;;
+  esac
+done
+shift `expr $OPTIND - 1`
+
+machine=`uname -m`
+os=`uname -s`
+
+if test "x$TMPDIR" = "x"; then
+  tmp="/tmp"
+else
+  tmp=$TMPDIR
+fi
+# secure-ish temp dir creation without having mktemp available (DDoS-able but not expliotable)
+tmp_dir="$tmp/install.sh.$$"
+(umask 077 && mkdir $tmp_dir) || exit 1
+
+#
+# Platform and Platform Version detection
+#
+# NOTE: This should now match ohai platform and platform_version matching.
+# do not invented new platform and platform_version schemas, just make this behave
+# like what ohai returns as platform and platform_version for the server.
+#
+# ALSO NOTE: Do not mangle platform or platform_version here.  It is less error
+# prone and more future-proof to do that in the server, and then all omnitruck clients
+# will 'inherit' the changes (install.sh is not the only client of the omnitruck
+# endpoint out there).
+#
+
+if test -f "/etc/lsb-release" && grep -q DISTRIB_ID /etc/lsb-release; then
+  platform=`grep DISTRIB_ID /etc/lsb-release | cut -d "=" -f 2 | tr '[A-Z]' '[a-z]'`
+  platform_version=`grep DISTRIB_RELEASE /etc/lsb-release | cut -d "=" -f 2`
+elif test -f "/etc/debian_version"; then
+  platform="debian"
+  platform_version=`cat /etc/debian_version`
+elif test -f "/etc/redhat-release"; then
+  platform=`sed 's/^\(.\+\) release.*/\1/' /etc/redhat-release | tr '[A-Z]' '[a-z]'`
+  platform_version=`sed 's/^.\+ release \([.0-9]\+\).*/\1/' /etc/redhat-release`
+
+  # If /etc/redhat-release exists, we act like RHEL by default
+  if test "$platform" = "fedora"; then
+    # FIXME: stop remapping fedora to el
+    # FIXME: remove client side platform_version mangling and hard coded yolo
+    # Change platform version for use below.
+    platform_version="6.0"
+  fi
+
+  if test "$platform" = "xenserver"; then
+    # Current XenServer 6.2 is based on CentOS 5, platform is not reset to "el" server should hanlde response
+    platform="xenserver"
+  else
+    # FIXME: use "redhat"
+    platform="el"
+  fi
+
+elif test -f "/etc/system-release"; then
+  platform=`sed 's/^\(.\+\) release.\+/\1/' /etc/system-release | tr '[A-Z]' '[a-z]'`
+  platform_version=`sed 's/^.\+ release \([.0-9]\+\).*/\1/' /etc/system-release | tr '[A-Z]' '[a-z]'`
+  # amazon is built off of fedora, so act like RHEL
+  if test "$platform" = "amazon linux ami"; then
+    # FIXME: remove client side platform_version mangling and hard coded yolo, and remapping to deprecated "el"
+    platform="el"
+    platform_version="6.0"
+  fi
+# Apple OS X
+elif test -f "/usr/bin/sw_vers"; then
+  platform="mac_os_x"
+  # Matching the tab-space with sed is error-prone
+  platform_version=`sw_vers | awk '/^ProductVersion:/ { print $2 }' | cut -d. -f1,2`
+
+  # x86_64 Apple hardware often runs 32-bit kernels (see OHAI-63)
+  x86_64=`sysctl -n hw.optional.x86_64`
+  if test $x86_64 -eq 1; then
+    machine="x86_64"
+  fi
+elif test -f "/etc/release"; then
+  machine=`/usr/bin/uname -p`
+  if grep -q SmartOS /etc/release; then
+    platform="smartos"
+    platform_version=`grep ^Image /etc/product | awk '{ print $3 }'`
+  else
+    platform="solaris2"
+    platform_version=`/usr/bin/uname -r`
+  fi
+elif test -f "/etc/SuSE-release"; then
+  if grep -q 'Enterprise' /etc/SuSE-release;
+  then
+      platform="sles"
+      platform_version=`awk '/^VERSION/ {V = $3}; /^PATCHLEVEL/ {P = $3}; END {print V "." P}' /etc/SuSE-release`
+  else
+      platform="suse"
+      platform_version=`awk '/^VERSION =/ { print $3 }' /etc/SuSE-release`
+  fi
+elif test "x$os" = "xFreeBSD"; then
+  platform="freebsd"
+  platform_version=`uname -r | sed 's/-.*//'`
+elif test "x$os" = "xAIX"; then
+  platform="aix"
+  platform_version="`uname -v`.`uname -r`"
+  machine="powerpc"
+fi
+
+if test "x$platform" = "x"; then
+  echo "Unable to determine platform version!"
+  report_bug
+  exit 1
+fi
+
+#
+# NOTE: platform manging in the install.sh is DEPRECATED
+#
+# - install.sh should be true to ohai and should not remap
+#   platform or platform versions.
+#
+# - remapping platform and mangling platform version numbers is
+#   now the complete responsibility of the server-side endpoints
+#
+
+major_version=`echo $platform_version | cut -d. -f1`
+case $platform in
+  # FIXME: should remove this case statement completely
+  "el")
+    # FIXME:  "el" is deprecated, should use "redhat"
+    platform_version=$major_version
+    ;;
+  "debian")
+    # FIXME: remove client-side yolo here
+    case $major_version in
+      "5") platform_version="6";;  # FIXME: need to port this "reverse-yolo" into platform.rb
+      "6") platform_version="6";;
+      "7") platform_version="6";;
+    esac
+    ;;
+  "freebsd")
+    platform_version=$major_version
+    ;;
+  "sles")
+    platform_version=$major_version
+    ;;
+  "suse")
+    platform_version=$major_version
+    ;;
+esac
+
+if test "x$platform_version" = "x"; then
+  echo "Unable to determine platform version!"
+  report_bug
+  exit 1
+fi
+
+if test "x$platform" = "xsolaris2"; then
+  # hack up the path on Solaris to find wget, pkgadd
+  PATH=/usr/sfw/bin:/usr/sbin:$PATH
+  export PATH
+fi
+
+checksum_mismatch() {
+  echo "Package checksum mismatch!"
+  report_bug
+  exit 1
+}
+
+unable_to_retrieve_package() {
+  echo "Unable to retrieve a valid package!"
+  report_bug
+  echo "Metadata URL: $metadata_url"
+  if test "x$download_url" != "x"; then
+    echo "Download URL: $download_url"
+  fi
+  if test "x$stderr_results" != "x"; then
+    echo "\nDEBUG OUTPUT FOLLOWS:\n$stderr_results"
+  fi
+  exit 1
+}
+
+http_404_error() {
+  echo "Omnitruck artifact does not exist for version $version on platform $platform"
+  echo ""
+  echo "Either this means:"
+  echo "   - We do not support $platform"
+  echo "   - We do not have an artifact for $version"
+  echo ""
+  echo "This is often the latter case due to running a prerelease or RC version of chef"
+  echo "or a gem version which was only pushed to rubygems and not omnitruck."
+  echo ""
+  echo "You may be able to set your knife[:bootstrap_version] to the most recent stable"
+  echo "release of Chef to fix this problem (or the most recent stable major version number)."
+  echo ""
+  echo "In order to test the version parameter, adventurous users may take the Metadata URL"
+  echo "below and modify the '&v=<number>' parameter until you successfully get a URL that"
+  echo "does not 404 (e.g. via curl or wget).  You should be able to use '&v=11' or '&v=12'"
+  echo "succesfully."
+  echo ""
+  echo "If you cannot fix this problem by setting the bootstrap_version, it probably means"
+  echo "that $platform is not supported."
+  echo ""
+  # deliberately do not call report_bug to suppress bug report noise.
+  echo "Metadata URL: $metadata_url"
+  if test "x$download_url" != "x"; then
+    echo "Download URL: $download_url"
+  fi
+  if test "x$stderr_results" != "x"; then
+    echo "\nDEBUG OUTPUT FOLLOWS:\n$stderr_results"
+  fi
+  exit 1
+}
+
+capture_tmp_stderr() {
+  # spool up /tmp/stderr from all the commands we called
+  if test -f "$tmp_dir/stderr"; then
+    output=`cat $tmp_dir/stderr`
+    stderr_results="${stderr_results}\nSTDERR from $1:\n\n$output\n"
+    rm $tmp_dir/stderr
+  fi
+}
+
+# do_wget URL FILENAME
+do_wget() {
+  echo "trying wget..."
+  wget -O "$2" "$1" 2>$tmp_dir/stderr
+  rc=$?
+  # check for 404
+  grep "ERROR 404" $tmp_dir/stderr 2>&1 >/dev/null
+  if test $? -eq 0; then
+    echo "ERROR 404"
+    http_404_error
+  fi
+
+  # check for bad return status or empty output
+  if test $rc -ne 0 || test ! -s "$2"; then
+    capture_tmp_stderr "wget"
+    return 1
+  fi
+
+  return 0
+}
+
+# do_curl URL FILENAME
+do_curl() {
+  echo "trying curl..."
+  curl -sL -D $tmp_dir/stderr "$1" > "$2"
+  rc=$?
+  # check for 404
+  grep "404 Not Found" $tmp_dir/stderr 2>&1 >/dev/null
+  if test $? -eq 0; then
+    echo "ERROR 404"
+    http_404_error
+  fi
+
+  # check for bad return status or empty output
+  if test $rc -ne 0 || test ! -s "$2"; then
+    capture_tmp_stderr "curl"
+    return 1
+  fi
+
+  return 0
+}
+
+# do_fetch URL FILENAME
+do_fetch() {
+  echo "trying fetch..."
+  fetch -o "$2" "$1" 2>$tmp_dir/stderr
+  # check for bad return status
+  test $? -ne 0 && return 1
+  return 0
+}
+
+# do_curl URL FILENAME
+do_perl() {
+  echo "trying perl..."
+  perl -e 'use LWP::Simple; getprint($ARGV[0]);' "$1" > "$2" 2>$tmp_dir/stderr
+  rc=$?
+  # check for 404
+  grep "404 Not Found" $tmp_dir/stderr 2>&1 >/dev/null
+  if test $? -eq 0; then
+    echo "ERROR 404"
+    http_404_error
+  fi
+
+  # check for bad return status or empty output
+  if test $rc -ne 0 || test ! -s "$2"; then
+    capture_tmp_stderr "perl"
+    return 1
+  fi
+
+  return 0
+}
+
+# do_curl URL FILENAME
+do_python() {
+  echo "trying python..."
+  python -c "import sys,urllib2 ; sys.stdout.write(urllib2.urlopen(sys.argv[1]).read())" "$1" > "$2" 2>$tmp_dir/stderr
+  rc=$?
+  # check for 404
+  grep "HTTP Error 404" $tmp_dir/stderr 2>&1 >/dev/null
+  if test $? -eq 0; then
+    echo "ERROR 404"
+    http_404_error
+  fi
+
+  # check for bad return status or empty output
+  if test $rc -ne 0 || test ! -s "$2"; then
+    capture_tmp_stderr "python"
+    return 1
+  fi
+  return 0
+}
+
+# returns 0 if checksums match
+do_checksum() {
+  if exists sha256sum; then
+    echo "Comparing checksum with sha256sum..."
+    checksum=`sha256sum $1 | awk '{ print $1 }'`
+    return `test "x$checksum" = "x$2"`
+  elif exists shasum; then
+    echo "Comparing checksum with shasum..."
+    checksum=`shasum -a 256 $1 | awk '{ print $1 }'`
+    return `test "x$checksum" = "x$2"`
+  elif exists md5sum; then
+    echo "Comparing checksum with md5sum..."
+    checksum=`md5sum $1 | awk '{ print $1 }'`
+    return `test "x$checksum" = "x$3"`
+  elif exists md5; then
+    echo "Comparing checksum with md5..."
+    # this is for md5 utility on MacOSX (OSX 10.6-10.10) and $4 is the correct field
+    checksum=`md5 $1 | awk '{ print $4 }'`
+    return `test "x$checksum" = "x$3"`
+  else
+    echo "WARNING: could not find a valid checksum program, pre-install shasum, md5sum or md5 in your O/S image to get valdation..."
+    return 0
+  fi
+}
+
+# do_download URL FILENAME
+do_download() {
+  echo "downloading $1"
+  echo "  to file $2"
+
+  # we try all of these until we get success.
+  # perl, in particular may be present but LWP::Simple may not be installed
+
+  if exists wget; then
+    do_wget $1 $2 && return 0
+  fi
+
+  if exists curl; then
+    do_curl $1 $2 && return 0
+  fi
+
+  if exists fetch; then
+    do_fetch $1 $2 && return 0
+  fi
+
+  if exists perl; then
+    do_perl $1 $2 && return 0
+  fi
+
+  if exists python; then
+    do_python $1 $2 && return 0
+  fi
+
+  unable_to_retrieve_package
+}
+
+# install_file TYPE FILENAME
+# TYPE is "rpm", "deb", "solaris", "sh", etc.
+install_file() {
+  echo "Installing Chef $version"
+  case "$1" in
+    "rpm")
+      echo "installing with rpm..."
+      rpm -Uvh --oldpackage --replacepkgs "$2"
+      ;;
+    "deb")
+      echo "installing with dpkg..."
+      dpkg -i "$2"
+      ;;
+    "bff")
+      echo "installing with installp..."
+      installp -aXYgd "$2" all
+      ;;
+    "solaris")
+      echo "installing with pkgadd..."
+      echo "conflict=nocheck" > $tmp_dir/nocheck
+      echo "action=nocheck" >> $tmp_dir/nocheck
+      echo "mail=" >> $tmp_dir/nocheck
+      pkgrm -a $tmp_dir/nocheck -n $project >/dev/null 2>&1 || true
+      pkgadd -n -d "$2" -a $tmp_dir/nocheck $project
+      ;;
+    "pkg")
+      echo "installing with installer..."
+      cd / && /usr/sbin/installer -pkg "$2" -target /
+      ;;
+    "dmg")
+      echo "installing dmg file..."
+      hdiutil detach "/Volumes/chef_software" >/dev/null 2>&1 || true
+      hdiutil attach "$2" -mountpoint "/Volumes/chef_software"
+      cd / && /usr/sbin/installer -pkg `find "/Volumes/chef_software" -name \*.pkg` -target /
+      hdiutil detach "/Volumes/chef_software"
+      ;;
+    "sh" )
+      echo "installing with sh..."
+      sh "$2"
+      ;;
+    *)
+      echo "Unknown filetype: $1"
+      report_bug
+      exit 1
+      ;;
+  esac
+  if test $? -ne 0; then
+    echo "Installation failed"
+    report_bug
+    exit 1
+  fi
+}
+
+echo "Downloading Chef $version for ${platform}..."
+
+
+metadata_filename="$tmp_dir/metadata.txt"
+
+case "$project" in
+  "chef")
+    metadata_url="https://www.opscode.com/chef/metadata?v=${version}&prerelease=${prerelease}&nightlies=${nightlies}&p=${platform}&pv=${platform_version}&m=${machine}"
+    ;;
+  "angrychef")
+    metadata_url="https://www.opscode.com/chef/metadata-angrychef?v=${version}&prerelease=${prerelease}&nightlies=${nightlies}&p=${platform}&pv=${platform_version}&m=${machine}"
+    ;;
+  "server")
+    metadata_url="https://www.opscode.com/chef/metadata-server?v=${version}&prerelease=${prerelease}&nightlies=${nightlies}&p=${platform}&pv=${platform_version}&m=${machine}"
+    ;;
+  "chefdk")
+    metadata_url="https://www.opscode.com/chef/metadata-chefdk?v=${version}&prerelease=${prerelease}&nightlies=${nightlies}&p=${platform}&pv=${platform_version}&m=${machine}"
+    ;;
+  "container")
+    metadata_url="https://www.opscode.com/chef/metadata-container?v=${version}&prerelease=${prerelease}&nightlies=${nightlies}&p=${platform}&pv=${platform_version}&m=${machine}"
+    ;;
+    *)
+esac
+
+if test "x$platform" = "xsolaris2"; then
+  if test "x$platform_version" = "x5.9" -o "x$platform_version" = "x5.10"; then
+    # solaris 9 lacks openssl, solaris 10 lacks recent enough credentials - your base O/S is completely insecure, please upgrade
+    metadata_url=`echo $metadata_url | sed -e 's/https/http/'`
+  fi
+fi
+
+do_download "$metadata_url"  "$metadata_filename"
+
+cat "$metadata_filename"
+
+# check that all the mandatory fields in the downloaded metadata are there
+if grep '^url' $metadata_filename > /dev/null && grep '^sha256' $metadata_filename > /dev/null && grep '^md5' $metadata_filename > /dev/null; then
+  echo "downloaded metadata file looks valid..."
+else
+  echo "downloaded metadata file is corrupted or an uncaught error was encountered in downloading the file..."
+  # this generally means one of the download methods downloaded a 404 or something like that and then reported a successful exit code,
+  # and this should be fixed in the function that was doing the download.
+  report_bug
+  exit 1
+fi
+
+download_url=`awk '$1 == "url" { print $2 }' "$metadata_filename"`
+
+if test "x$platform" = "xsolaris2"; then
+  if test "x$platform_version" = "x5.9" -o "x$platform_version" = "x5.10"; then
+    # solaris 9 lacks openssl, solaris 10 lacks recent enough credentials - your base O/S is completely insecure, please upgrade
+    download_url=`echo $download_url | sed -e 's/https/http/'`
+  fi
+fi
+
+filename=`echo $download_url | sed -e 's/^.*\///'`
+filetype=`echo $filename | sed -e 's/^.*\.//'`
+
+# use either $tmp_dir, the provided directory (-d) or the provided filename (-f)
+if test "x$cmdline_filename" != "x"; then
+  download_filename="$cmdline_filename"
+elif test "x$cmdline_dl_dir" != "x"; then
+  download_filename="$cmdline_dl_dir/$filename"
+else
+  download_filename="$tmp_dir/$filename"
+fi
+
+# ensure the parent directory where to download the installer always exists
+download_dir=`dirname $download_filename`
+(umask 077 && mkdir -p $download_dir) || exit 1
+
+sha256=`awk '$1 == "sha256" { print $2 }' "$metadata_filename"`
+md5=`awk '$1 == "md5" { print $2 }' "$metadata_filename"`
+
+# check if we have that file locally available and if so verify the checksum
+cached_file_available="false"
+if test -f $download_filename; then
+  echo "$download_filename already exists, verifiying checksum..."
+  if do_checksum "$download_filename" "$sha256" "$md5"; then
+    echo "checksum compare succeeded, using existing file!"
+    cached_file_available="true"
+  else
+    echo "checksum mismatch, downloading latest version of the file"
+  fi
+fi
+
+# download if no local version of the file available
+if test "x$cached_file_available" != "xtrue"; then
+  do_download "$download_url"  "$download_filename"
+  do_checksum "$download_filename" "$sha256" "$md5" || checksum_mismatch
+fi
+
+if test "x$version" = "x"; then
+  echo
+  echo "WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING"
+  echo
+  echo "You are installing an omnibus package without a version pin.  If you are installing"
+  echo "on production servers via an automated process this is DANGEROUS and you will"
+  echo "be upgraded without warning on new releases, even to new major releases."
+  echo "Letting the version float is only appropriate in desktop, test, development or"
+  echo "CI/CD environments."
+  echo
+  echo "WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING"
+  echo
+fi
+
+install_file $filetype "$download_filename"
+
+if test "x$tmp_dir" != "x"; then
+  rm -r "$tmp_dir"
+fi

--- a/charms/precise/clearwater-bono/lib/chef_solo_install
+++ b/charms/precise/clearwater-bono/lib/chef_solo_install
@@ -5,9 +5,7 @@
 apt-get -y install git libxml2-dev libxslt1-dev wget curl
 
 # Install chef
-install_sh="http://opscode.com/chef/install.sh"
-version_string="-v 11.6.0"
-bash <(wget  ${install_sh} -O -) ${version_string}
+$CHARM_DIR/lib/chef-install.sh -v 11.6.0
 
 # Pull down the Clearwater chef recipes
 if [ ! -d /home/ubuntu/chef-solo ]

--- a/charms/precise/clearwater-ellis/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-ellis/hooks/programmable-multiple-relation-changed
@@ -16,6 +16,9 @@ then
   grep -v ^RESOLV_CONF= /etc/default/dnsmasq > /tmp/dnsmasq.$$
   mv /tmp/dnsmasq.$$ /etc/default/dnsmasq
   echo RESOLV_CONF=/etc/dnsmasq.resolv.conf >> /etc/default/dnsmasq
+  # Disable caching of negative responses - this prevents failures if we start querying before the
+  # DNS charm has updated its records
+  sed -i "s/#no-negcache/no-negcache/g" /etc/dnsmasq.conf
   service dnsmasq restart
 fi
 

--- a/charms/precise/clearwater-ellis/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-ellis/hooks/programmable-multiple-relation-changed
@@ -17,7 +17,13 @@ then
   mv /tmp/dnsmasq.$$ /etc/default/dnsmasq
   echo RESOLV_CONF=/etc/dnsmasq.resolv.conf >> /etc/default/dnsmasq
   # Disable caching of negative responses - this prevents failures if we start querying before the
-  # DNS charm has updated its records
+  # DNS charm has updated its records.
+  #
+  # This is needed for Ellis because:
+  #   * Ellis sends a ping request to Homer and Homestead on startup, so suffers from bad DNS
+  #     records on startup
+  #   * We don't have any way to wait until the DNS server has definitely updated before restarting
+  #   Ellis.
   sed -i "s/#no-negcache/no-negcache/g" /etc/dnsmasq.conf
   service dnsmasq restart
 fi

--- a/tests/01-basictest
+++ b/tests/01-basictest
@@ -1,0 +1,38 @@
+#!/usr/bin/python
+
+import amulet
+import subprocess
+import sys, os
+
+# Load our recommended bundle
+d = amulet.Deployment.from_bundle("charms/bundles/clearwater/bundle/bundles.yaml")
+
+# Configure 'testing.example.com' as the common home domain, and 'testing' as
+# the Ellis signup key
+options = {'zone': 'testing.example.com'}
+for service in ['clearwater-bono', 'clearwater-sprout', 'clearwater-ralf', 'clearwater-homestead', 'clearwater-homer', 'clearwater-ellis']:
+    d.configure(service, options)
+
+d.configure('clearwater-ellis', options={'signup_key': 'testing'})
+d.configure('dns', options={'domain': 'testing.example.com'})
+
+# Exposed services aren't learnt from the bundle - do that manually
+d.expose('clearwater-ellis')
+d.expose('clearwater-bono')
+
+# Create the deployment described above, give us 900 seconds to do it
+d.setup(timeout=900)
+# Setup will only make sure the services are deployed, related, and in a
+# "started" state. We can employ the sentries to actually make sure there
+# are no more hooks being executed on any of the nodes.
+d.sentry.wait()
+
+# Learn the public IP addresses of Bono and Ellis
+bono = d.sentry['clearwater-bono/0'].info['public-address']
+ellis = d.sentry['clearwater-ellis/0'].info['public-address']
+
+# Run the 'basic call' test against Bono and Ellis
+sys.stderr.write('About to run live tests\n')
+subprocess.check_call(
+    'cd tests/clearwater-live-test && bundle install --path localgems && bundle exec rake test[testing.example.com] TESTS="Basic Call - Mainline" TRANSPORT=TCP ELLIS={} PROXY={} SIGNUP_CODE="testing" >&2'.format(ellis, bono),
+    shell=True)

--- a/tests/01-basictest
+++ b/tests/01-basictest
@@ -1,5 +1,37 @@
 #!/usr/bin/python
 
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2015 Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
 import amulet
 import subprocess
 import sys, os


### PR DESCRIPTION
Ellie,

Can you review these changes to our Juju charms? They apply markups from the Canonical charm review.

I've:
- added an Amulet test to deploy the system and make a call (which I've run successfully)
- packaged the Chef install script in the charm, to remove the risk of a corrupted download (it's Apache 2 licensed, but I will get it OKed before merging)
- stopped calling the config-changed hook after upgrade - apparently Juju does that for us
- disabled caching of negative responses in dnsmasq - I saw Amulet test failures because Ellis tried to contact Homer/Homestead at startup before the DNS charm had updated DNS, and the negative response got cached
