### PR TITLE
[Reviewer: Ellie] Configurable overload thresholds

### DIFF
--- a/charms/precise/clearwater-bono/config.yaml
+++ b/charms/precise/clearwater-bono/config.yaml
@@ -15,6 +15,10 @@ options:
     default: ""
     description: Comma-separated list of IP addresses of trusted peers
     type: string
+  target_latency_us:
+    default: 100000
+    description: Target request latency for overload control (microseconds)
+    type: int
   repo:
     default: http://repo.cw-ngv.com/juju-clearwater-1/
     description: The location of the repo server

--- a/charms/precise/clearwater-bono/lib/config_script
+++ b/charms/precise/clearwater-bono/lib/config_script
@@ -22,6 +22,7 @@ local_ip=$(unit-get private-address)
 public_ip=$(unit-get public-address)
 public_hostname=bono-$(cut -d/ -f2 <<< $JUJU_UNIT_NAME).$(config-get zone)
 turn_workaround=$(config-get turn_workaround)
+target_latency_us=$(config-get target_latency_us)
 
 # Write configuration back
 mkdir -p /etc/clearwater
@@ -43,4 +44,5 @@ public_hostname=$public_hostname
 
 # Keys
 turn_workaround=$turn_workaround
+target_latency_us=$target_latency_us
 EOF

--- a/charms/precise/clearwater-homestead/config.yaml
+++ b/charms/precise/clearwater-homestead/config.yaml
@@ -6,6 +6,10 @@ options:
     default: ""
     description: The location of the SAS server
     type: string
+  target_latency_us:
+    default: 1000000
+    description: Target request latency for overload control (microseconds)
+    type: int
   repo:
     default: http://repo.cw-ngv.com/juju-clearwater-1/
     description: The location of the repo server

--- a/charms/precise/clearwater-homestead/config.yaml
+++ b/charms/precise/clearwater-homestead/config.yaml
@@ -7,7 +7,7 @@ options:
     description: The location of the SAS server
     type: string
   target_latency_us:
-    default: 1000000
+    default: 100000
     description: Target request latency for overload control (microseconds)
     type: int
   repo:

--- a/charms/precise/clearwater-homestead/lib/config_script
+++ b/charms/precise/clearwater-homestead/lib/config_script
@@ -22,6 +22,7 @@ sas_server=$(config-get sas)
 local_ip=$(unit-get private-address)
 public_ip=$(unit-get public-address)
 public_hostname=homestead-$(cut -d/ -f2 <<< $JUJU_UNIT_NAME).$(config-get zone)
+target_latency_us=$(config-get target_latency_us)
 
 # Write configuration back
 mkdir -p /etc/clearwater
@@ -40,4 +41,5 @@ enum_server=$enum_server
 local_ip=$local_ip
 public_ip=$public_ip
 public_hostname=$public_hostname
+target_latency_us=$target_latency_us
 EOF

--- a/charms/precise/clearwater-ralf/config.yaml
+++ b/charms/precise/clearwater-ralf/config.yaml
@@ -6,6 +6,10 @@ options:
     default: ""
     description: The location of the SAS server
     type: string
+  target_latency_us:
+      default: 100000
+      description: Target request latency for overload control (microseconds)
+      type: int
   repo:
     default: http://repo.cw-ngv.com/juju-clearwater-1/
     description: The location of the repo server

--- a/charms/precise/clearwater-ralf/lib/config_script
+++ b/charms/precise/clearwater-ralf/lib/config_script
@@ -22,6 +22,7 @@ sas_server=$(config-get sas)
 local_ip=$(unit-get private-address)
 public_ip=$(unit-get public-address)
 public_hostname=ralf-$(cut -d/ -f2 <<< $JUJU_UNIT_NAME).$(config-get zone)
+target_latency_us=$(config-get target_latency_us)
 
 # Write configuration back
 mkdir -p /etc/clearwater
@@ -35,6 +36,7 @@ xdms_hostname=$xdms_hostname
 ralf_hostname=$ralf_hostname
 sas_server=$sas_server
 enum_server=$enum_server
+target_latency_us=$target_latency_us
 
 # Local IP configuration
 local_ip=$local_ip

--- a/charms/precise/clearwater-sprout/config.yaml
+++ b/charms/precise/clearwater-sprout/config.yaml
@@ -18,6 +18,10 @@ options:
     default: 600
     description: Maximum session expiry time (sec)
     type: int
+  target_latency_us:
+    default: 1000000
+    description: Target request latency for overload control (microseconds)
+    type: int
   repo:
     default: http://repo.cw-ngv.com/juju-clearwater-1/
     description: The location of the repo server

--- a/charms/precise/clearwater-sprout/config.yaml
+++ b/charms/precise/clearwater-sprout/config.yaml
@@ -19,7 +19,7 @@ options:
     description: Maximum session expiry time (sec)
     type: int
   target_latency_us:
-    default: 1000000
+    default: 100000
     description: Target request latency for overload control (microseconds)
     type: int
   repo:

--- a/charms/precise/clearwater-sprout/lib/config_script
+++ b/charms/precise/clearwater-sprout/lib/config_script
@@ -28,6 +28,7 @@ public_ip=$(unit-get public-address)
 public_hostname=sprout-$(cut -d/ -f2 <<< $JUJU_UNIT_NAME).$(config-get zone)
 reg_max_expires=$(config-get reg_max_expires)
 default_session_expires=$(config-get session_max_expires)
+target_latency_us=$(config-get target_latency_us)
 
 # Write configuration back
 mkdir -p /etc/clearwater
@@ -50,4 +51,5 @@ public_hostname=$public_hostname
 
 reg_max_expires=$reg_max_expires
 default_session_expires=$default_session_expires
+target_latency_us=$target_latency_us
 EOF


### PR DESCRIPTION
This lets Juju users change the target latency away from 100ms, in case they want to be more forgiving of slow calls in order to get fewer call failures during load spikes.
