### PR TITLE
[Don't merge until released Juju DNS charm supports JSON] Generate JSON-form DNS records to integrate with the latest DNS charm

### DIFF
--- a/charms/precise/clearwater-bono/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-bono/hooks/programmable-multiple-relation-changed
@@ -7,7 +7,7 @@ ip=$(unit-get public-address)
 relation-set domain=$(config-get zone)
 DNS_JSON=$($CHARM_DIR/lib/generate_dns_records $ip @ bono-$id 5060 _sip._tcp _sip._udp)
 DNS_JSON="'$DNS_JSON'"
-relation-set resources=$DNS_JSON
+relation-set resources="$DNS_JSON"
 
 # Update our DNS server
 if [ "$(relation-get private-address)" != "" ]

--- a/charms/precise/clearwater-bono/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-bono/hooks/programmable-multiple-relation-changed
@@ -5,7 +5,8 @@ set -e
 id=$(cut -d/ -f2 <<< $JUJU_UNIT_NAME)
 ip=$(unit-get public-address)
 relation-set domain=$(config-get zone)
-DNS_JSON=`$CHARM_DIR/lib/generate_dns_records $ip @ bono-$id 5060 _sip._tcp _sip._udp`
+DNS_JSON=$($CHARM_DIR/lib/generate_dns_records $ip @ bono-$id 5060 _sip._tcp _sip._udp)
+DNS_JSON="'$DNS_JSON'"
 relation-set resources=$DNS_JSON
 
 # Update our DNS server

--- a/charms/precise/clearwater-bono/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-bono/hooks/programmable-multiple-relation-changed
@@ -6,7 +6,6 @@ id=$(cut -d/ -f2 <<< $JUJU_UNIT_NAME)
 ip=$(unit-get public-address)
 relation-set domain=$(config-get zone)
 DNS_JSON=$($CHARM_DIR/lib/generate_dns_records $ip @ bono-$id 5060 _sip._tcp _sip._udp)
-DNS_JSON="'$DNS_JSON'"
 relation-set resources="$DNS_JSON"
 
 # Update our DNS server

--- a/charms/precise/clearwater-bono/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-bono/hooks/programmable-multiple-relation-changed
@@ -2,16 +2,11 @@
 set -e
 
 # Set our DNS requirements
-TTL=300
 id=$(cut -d/ -f2 <<< $JUJU_UNIT_NAME)
 ip=$(unit-get public-address)
 relation-set domain=$(config-get zone)
-relation-set resources='@ '$TTL' IN A '$ip'
-@ '$TTL' IN NAPTR 1 1 "S" "SIP+D2T" "" _sip._tcp
-@ '$TTL' IN NAPTR 2 1 "S" "SIP+D2U" "" _sip._udp
-_sip._tcp '$TTL' IN SRV 0 0 5060 bono-'$id'
-_sip._udp '$TTL' IN SRV 0 0 5060 bono-'$id'
-bono-'$id' '$TTL' IN A '$ip
+DNS_JSON=`$CHARM_DIR/lib/generate_dns_records $ip @ bono-$id 5060 _sip._tcp _sip._udp`
+relation-set resources=$DNS_JSON
 
 # Update our DNS server
 if [ "$(relation-get private-address)" != "" ]

--- a/charms/precise/clearwater-bono/lib/generate_dns_records
+++ b/charms/precise/clearwater-bono/lib/generate_dns_records
@@ -1,0 +1,63 @@
+#!/usr/bin/python
+
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2015 Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+# This script generates a JSON-ified set of DNS records based on an IP, A
+# records and SRV records. These are suitable for the API to
+# https://github.com/chuckbutler/DNS-Charm.
+
+import sys
+import json
+
+if len(sys.argv) < 4:
+    print "Usage: generate_dns_records.py IP CLUSTER_A_RECORD SPECIFIC_A_RECORD [SRV_PORT SRV_ADDR...]"
+
+ip = sys.argv[1]
+cluster_a = sys.argv[2]
+specific_a = sys.argv[3]
+port = None
+srv_addrs = []
+
+ttl = "300"
+
+if len(sys.argv) > 5:
+    port = sys.argv[4]
+    srv_addrs = sys.argv[5:]
+
+ret = [{"rr":"A", "alias": cluster_a, "ttl": ttl,"addr": ip},
+       {"rr":"A", "alias": specific_a, "ttl": ttl,"addr": ip}]
+
+for a in srv_addrs:
+    ret.append({"rr": "SRV", "alias": a, "ttl": ttl,"priority": "1", "weight": "1", "port": port, "target": specific_a})
+
+print json.dumps(ret)

--- a/charms/precise/clearwater-ellis/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-ellis/hooks/programmable-multiple-relation-changed
@@ -7,7 +7,7 @@ ip=$(unit-get public-address)
 relation-set domain=$(config-get zone)
 DNS_JSON=$($CHARM_DIR/lib/generate_dns_records $ip ellis ellis-$id)
 DNS_JSON="'$DNS_JSON'"
-relation-set resources=$DNS_JSON
+relation-set resources="$DNS_JSON"
 
 # Update our DNS server
 if [ "$(relation-get private-address)" != "" ]

--- a/charms/precise/clearwater-ellis/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-ellis/hooks/programmable-multiple-relation-changed
@@ -5,7 +5,8 @@ set -e
 id=$(cut -d/ -f2 <<< $JUJU_UNIT_NAME)
 ip=$(unit-get public-address)
 relation-set domain=$(config-get zone)
-DNS_JSON=`$CHARM_DIR/lib/generate_dns_records $ip ellis ellis-$id`
+DNS_JSON=$($CHARM_DIR/lib/generate_dns_records $ip ellis ellis-$id)
+DNS_JSON="'$DNS_JSON'"
 relation-set resources=$DNS_JSON
 
 # Update our DNS server

--- a/charms/precise/clearwater-ellis/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-ellis/hooks/programmable-multiple-relation-changed
@@ -6,7 +6,6 @@ id=$(cut -d/ -f2 <<< $JUJU_UNIT_NAME)
 ip=$(unit-get public-address)
 relation-set domain=$(config-get zone)
 DNS_JSON=$($CHARM_DIR/lib/generate_dns_records $ip ellis ellis-$id)
-DNS_JSON="'$DNS_JSON'"
 relation-set resources="$DNS_JSON"
 
 # Update our DNS server

--- a/charms/precise/clearwater-ellis/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-ellis/hooks/programmable-multiple-relation-changed
@@ -2,12 +2,11 @@
 set -e
 
 # Set our DNS requirements
-TTL=300
 id=$(cut -d/ -f2 <<< $JUJU_UNIT_NAME)
 ip=$(unit-get public-address)
 relation-set domain=$(config-get zone)
-relation-set resources='ellis '$TTL' IN A '$ip'
-ellis-'$id' '$TTL' IN A '$ip
+DNS_JSON=`$CHARM_DIR/lib/generate_dns_records $ip ellis ellis-$id`
+relation-set resources=$DNS_JSON
 
 # Update our DNS server
 if [ "$(relation-get private-address)" != "" ]

--- a/charms/precise/clearwater-ellis/lib/generate_dns_records
+++ b/charms/precise/clearwater-ellis/lib/generate_dns_records
@@ -1,0 +1,63 @@
+#!/usr/bin/python
+
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2015 Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+# This script generates a JSON-ified set of DNS records based on an IP, A
+# records and SRV records. These are suitable for the API to
+# https://github.com/chuckbutler/DNS-Charm.
+
+import sys
+import json
+
+if len(sys.argv) < 4:
+    print "Usage: generate_dns_records.py IP CLUSTER_A_RECORD SPECIFIC_A_RECORD [SRV_PORT SRV_ADDR...]"
+
+ip = sys.argv[1]
+cluster_a = sys.argv[2]
+specific_a = sys.argv[3]
+port = None
+srv_addrs = []
+
+ttl = "300"
+
+if len(sys.argv) > 5:
+    port = sys.argv[4]
+    srv_addrs = sys.argv[5:]
+
+ret = [{"rr":"A", "alias": cluster_a, "ttl": ttl,"addr": ip},
+       {"rr":"A", "alias": specific_a, "ttl": ttl,"addr": ip}]
+
+for a in srv_addrs:
+    ret.append({"rr": "SRV", "alias": a, "ttl": ttl,"priority": "1", "weight": "1", "port": port, "target": specific_a})
+
+print json.dumps(ret)

--- a/charms/precise/clearwater-homer/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-homer/hooks/programmable-multiple-relation-changed
@@ -7,7 +7,7 @@ ip=$(unit-get private-address)
 relation-set domain=$(config-get zone)
 DNS_JSON=$($CHARM_DIR/lib/generate_dns_records $ip homer homer-$id)
 DNS_JSON="'$DNS_JSON'"
-relation-set resources=$DNS_JSON
+relation-set resources="$DNS_JSON"
 
 # Update our DNS server
 if [ "$(relation-get private-address)" != "" ]

--- a/charms/precise/clearwater-homer/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-homer/hooks/programmable-multiple-relation-changed
@@ -5,7 +5,8 @@ set -e
 id=$(cut -d/ -f2 <<< $JUJU_UNIT_NAME)
 ip=$(unit-get private-address)
 relation-set domain=$(config-get zone)
-DNS_JSON=`$CHARM_DIR/lib/generate_dns_records $ip homer homer-$id`
+DNS_JSON=$($CHARM_DIR/lib/generate_dns_records $ip homer homer-$id)
+DNS_JSON="'$DNS_JSON'"
 relation-set resources=$DNS_JSON
 
 # Update our DNS server

--- a/charms/precise/clearwater-homer/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-homer/hooks/programmable-multiple-relation-changed
@@ -6,7 +6,6 @@ id=$(cut -d/ -f2 <<< $JUJU_UNIT_NAME)
 ip=$(unit-get private-address)
 relation-set domain=$(config-get zone)
 DNS_JSON=$($CHARM_DIR/lib/generate_dns_records $ip homer homer-$id)
-DNS_JSON="'$DNS_JSON'"
 relation-set resources="$DNS_JSON"
 
 # Update our DNS server

--- a/charms/precise/clearwater-homer/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-homer/hooks/programmable-multiple-relation-changed
@@ -2,12 +2,11 @@
 set -e
 
 # Set our DNS requirements
-TTL=300
 id=$(cut -d/ -f2 <<< $JUJU_UNIT_NAME)
 ip=$(unit-get private-address)
 relation-set domain=$(config-get zone)
-relation-set resources='homer '$TTL' IN A '$ip'
-homer-'$id' '$TTL' IN A '$ip
+DNS_JSON=`$CHARM_DIR/lib/generate_dns_records $ip homer homer-$id`
+relation-set resources=$DNS_JSON
 
 # Update our DNS server
 if [ "$(relation-get private-address)" != "" ]

--- a/charms/precise/clearwater-homer/lib/generate_dns_records
+++ b/charms/precise/clearwater-homer/lib/generate_dns_records
@@ -1,0 +1,63 @@
+#!/usr/bin/python
+
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2015 Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+# This script generates a JSON-ified set of DNS records based on an IP, A
+# records and SRV records. These are suitable for the API to
+# https://github.com/chuckbutler/DNS-Charm.
+
+import sys
+import json
+
+if len(sys.argv) < 4:
+    print "Usage: generate_dns_records.py IP CLUSTER_A_RECORD SPECIFIC_A_RECORD [SRV_PORT SRV_ADDR...]"
+
+ip = sys.argv[1]
+cluster_a = sys.argv[2]
+specific_a = sys.argv[3]
+port = None
+srv_addrs = []
+
+ttl = "300"
+
+if len(sys.argv) > 5:
+    port = sys.argv[4]
+    srv_addrs = sys.argv[5:]
+
+ret = [{"rr":"A", "alias": cluster_a, "ttl": ttl,"addr": ip},
+       {"rr":"A", "alias": specific_a, "ttl": ttl,"addr": ip}]
+
+for a in srv_addrs:
+    ret.append({"rr": "SRV", "alias": a, "ttl": ttl,"priority": "1", "weight": "1", "port": port, "target": specific_a})
+
+print json.dumps(ret)

--- a/charms/precise/clearwater-homestead/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-homestead/hooks/programmable-multiple-relation-changed
@@ -2,11 +2,11 @@
 set -e
 
 # Set our DNS requirements
-TTL=300
 id=$(cut -d/ -f2 <<< $JUJU_UNIT_NAME)
 ip=$(unit-get private-address)
 relation-set domain=$(config-get zone)
-DNS_JSON=`$CHARM_DIR/lib/generate_dns_records $ip homestead homestead-$id`
+DNS_JSON=$($CHARM_DIR/lib/generate_dns_records $ip homestead homestead-$id)
+DNS_JSON="'$DNS_JSON'"
 relation-set resources=$DNS_JSON
 
 # Update our DNS server

--- a/charms/precise/clearwater-homestead/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-homestead/hooks/programmable-multiple-relation-changed
@@ -6,8 +6,8 @@ TTL=300
 id=$(cut -d/ -f2 <<< $JUJU_UNIT_NAME)
 ip=$(unit-get private-address)
 relation-set domain=$(config-get zone)
-relation-set resources='homestead '$TTL' IN A '$ip'
-homestead-'$id' '$TTL' IN A '$ip
+DNS_JSON=`$CHARM_DIR/lib/generate_dns_records $ip homestead homestead-$id`
+relation-set resources=$DNS_JSON
 
 # Update our DNS server
 if [ "$(relation-get private-address)" != "" ]

--- a/charms/precise/clearwater-homestead/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-homestead/hooks/programmable-multiple-relation-changed
@@ -6,7 +6,6 @@ id=$(cut -d/ -f2 <<< $JUJU_UNIT_NAME)
 ip=$(unit-get private-address)
 relation-set domain=$(config-get zone)
 DNS_JSON=$($CHARM_DIR/lib/generate_dns_records $ip homestead homestead-$id)
-DNS_JSON="'$DNS_JSON'"
 relation-set resources="$DNS_JSON"
 
 # Update our DNS server

--- a/charms/precise/clearwater-homestead/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-homestead/hooks/programmable-multiple-relation-changed
@@ -7,7 +7,7 @@ ip=$(unit-get private-address)
 relation-set domain=$(config-get zone)
 DNS_JSON=$($CHARM_DIR/lib/generate_dns_records $ip homestead homestead-$id)
 DNS_JSON="'$DNS_JSON'"
-relation-set resources=$DNS_JSON
+relation-set resources="$DNS_JSON"
 
 # Update our DNS server
 if [ "$(relation-get private-address)" != "" ]

--- a/charms/precise/clearwater-homestead/lib/generate_dns_records
+++ b/charms/precise/clearwater-homestead/lib/generate_dns_records
@@ -1,0 +1,63 @@
+#!/usr/bin/python
+
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2015 Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+# This script generates a JSON-ified set of DNS records based on an IP, A
+# records and SRV records. These are suitable for the API to
+# https://github.com/chuckbutler/DNS-Charm.
+
+import sys
+import json
+
+if len(sys.argv) < 4:
+    print "Usage: generate_dns_records.py IP CLUSTER_A_RECORD SPECIFIC_A_RECORD [SRV_PORT SRV_ADDR...]"
+
+ip = sys.argv[1]
+cluster_a = sys.argv[2]
+specific_a = sys.argv[3]
+port = None
+srv_addrs = []
+
+ttl = "300"
+
+if len(sys.argv) > 5:
+    port = sys.argv[4]
+    srv_addrs = sys.argv[5:]
+
+ret = [{"rr":"A", "alias": cluster_a, "ttl": ttl,"addr": ip},
+       {"rr":"A", "alias": specific_a, "ttl": ttl,"addr": ip}]
+
+for a in srv_addrs:
+    ret.append({"rr": "SRV", "alias": a, "ttl": ttl,"priority": "1", "weight": "1", "port": port, "target": specific_a})
+
+print json.dumps(ret)

--- a/charms/precise/clearwater-ralf/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-ralf/hooks/programmable-multiple-relation-changed
@@ -2,12 +2,11 @@
 set -e
 
 # Set our DNS requirements
-TTL=300
 id=$(cut -d/ -f2 <<< $JUJU_UNIT_NAME)
 ip=$(unit-get private-address)
 relation-set domain=$(config-get zone)
-relation-set resources='ralf '$TTL' IN A '$ip'
-ralf-'$id' '$TTL' IN A '$ip
+DNS_JSON=`$CHARM_DIR/lib/generate_dns_records $ip ralf ralf-$id`
+relation-set resources=$DNS_JSON
 
 # Update our DNS server
 if [ "$(relation-get private-address)" != "" ]

--- a/charms/precise/clearwater-ralf/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-ralf/hooks/programmable-multiple-relation-changed
@@ -5,7 +5,8 @@ set -e
 id=$(cut -d/ -f2 <<< $JUJU_UNIT_NAME)
 ip=$(unit-get private-address)
 relation-set domain=$(config-get zone)
-DNS_JSON=`$CHARM_DIR/lib/generate_dns_records $ip ralf ralf-$id`
+DNS_JSON=$($CHARM_DIR/lib/generate_dns_records $ip ralf ralf-$id)
+DNS_JSON="'$DNS_JSON'"
 relation-set resources=$DNS_JSON
 
 # Update our DNS server

--- a/charms/precise/clearwater-ralf/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-ralf/hooks/programmable-multiple-relation-changed
@@ -7,7 +7,7 @@ ip=$(unit-get private-address)
 relation-set domain=$(config-get zone)
 DNS_JSON=$($CHARM_DIR/lib/generate_dns_records $ip ralf ralf-$id)
 DNS_JSON="'$DNS_JSON'"
-relation-set resources=$DNS_JSON
+relation-set resources="$DNS_JSON"
 
 # Update our DNS server
 if [ "$(relation-get private-address)" != "" ]

--- a/charms/precise/clearwater-ralf/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-ralf/hooks/programmable-multiple-relation-changed
@@ -6,7 +6,6 @@ id=$(cut -d/ -f2 <<< $JUJU_UNIT_NAME)
 ip=$(unit-get private-address)
 relation-set domain=$(config-get zone)
 DNS_JSON=$($CHARM_DIR/lib/generate_dns_records $ip ralf ralf-$id)
-DNS_JSON="'$DNS_JSON'"
 relation-set resources="$DNS_JSON"
 
 # Update our DNS server

--- a/charms/precise/clearwater-ralf/lib/generate_dns_records
+++ b/charms/precise/clearwater-ralf/lib/generate_dns_records
@@ -1,0 +1,63 @@
+#!/usr/bin/python
+
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2015 Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+# This script generates a JSON-ified set of DNS records based on an IP, A
+# records and SRV records. These are suitable for the API to
+# https://github.com/chuckbutler/DNS-Charm.
+
+import sys
+import json
+
+if len(sys.argv) < 4:
+    print "Usage: generate_dns_records.py IP CLUSTER_A_RECORD SPECIFIC_A_RECORD [SRV_PORT SRV_ADDR...]"
+
+ip = sys.argv[1]
+cluster_a = sys.argv[2]
+specific_a = sys.argv[3]
+port = None
+srv_addrs = []
+
+ttl = "300"
+
+if len(sys.argv) > 5:
+    port = sys.argv[4]
+    srv_addrs = sys.argv[5:]
+
+ret = [{"rr":"A", "alias": cluster_a, "ttl": ttl,"addr": ip},
+       {"rr":"A", "alias": specific_a, "ttl": ttl,"addr": ip}]
+
+for a in srv_addrs:
+    ret.append({"rr": "SRV", "alias": a, "ttl": ttl,"priority": "1", "weight": "1", "port": port, "target": specific_a})
+
+print json.dumps(ret)

--- a/charms/precise/clearwater-sipp/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-sipp/hooks/programmable-multiple-relation-changed
@@ -6,7 +6,6 @@ id=$(cut -d/ -f2 <<< $JUJU_UNIT_NAME)
 ip=$(unit-get public-address)
 relation-set domain=$(config-get zone)
 DNS_JSON=$($CHARM_DIR/lib/generate_dns_records $ip sipp sipp-$id)
-DNS_JSON="'$DNS_JSON'"
 relation-set resources="$DNS_JSON"
 
 # Update our DNS server

--- a/charms/precise/clearwater-sipp/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-sipp/hooks/programmable-multiple-relation-changed
@@ -7,7 +7,7 @@ ip=$(unit-get public-address)
 relation-set domain=$(config-get zone)
 DNS_JSON=$($CHARM_DIR/lib/generate_dns_records $ip sipp sipp-$id)
 DNS_JSON="'$DNS_JSON'"
-relation-set resources=$DNS_JSON
+relation-set resources="$DNS_JSON"
 
 # Update our DNS server
 if [ "$(relation-get private-address)" != "" ]

--- a/charms/precise/clearwater-sipp/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-sipp/hooks/programmable-multiple-relation-changed
@@ -5,9 +5,9 @@ set -e
 id=$(cut -d/ -f2 <<< $JUJU_UNIT_NAME)
 ip=$(unit-get public-address)
 relation-set domain=$(config-get zone)
-DNS_JSON=`$CHARM_DIR/lib/generate_dns_records $ip sipp sipp-$id`
+DNS_JSON=$($CHARM_DIR/lib/generate_dns_records $ip sipp sipp-$id)
+DNS_JSON="'$DNS_JSON'"
 relation-set resources=$DNS_JSON
-relation-set resources='sipp-'$id' '$TTL' IN A '$ip
 
 # Update our DNS server
 if [ "$(relation-get private-address)" != "" ]

--- a/charms/precise/clearwater-sipp/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-sipp/hooks/programmable-multiple-relation-changed
@@ -2,10 +2,11 @@
 set -e
 
 # Set our DNS requirements
-TTL=300
 id=$(cut -d/ -f2 <<< $JUJU_UNIT_NAME)
 ip=$(unit-get public-address)
 relation-set domain=$(config-get zone)
+DNS_JSON=`$CHARM_DIR/lib/generate_dns_records $ip sipp sipp-$id`
+relation-set resources=$DNS_JSON
 relation-set resources='sipp-'$id' '$TTL' IN A '$ip
 
 # Update our DNS server

--- a/charms/precise/clearwater-sipp/lib/generate_dns_records
+++ b/charms/precise/clearwater-sipp/lib/generate_dns_records
@@ -1,0 +1,63 @@
+#!/usr/bin/python
+
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2015 Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+# This script generates a JSON-ified set of DNS records based on an IP, A
+# records and SRV records. These are suitable for the API to
+# https://github.com/chuckbutler/DNS-Charm.
+
+import sys
+import json
+
+if len(sys.argv) < 4:
+    print "Usage: generate_dns_records.py IP CLUSTER_A_RECORD SPECIFIC_A_RECORD [SRV_PORT SRV_ADDR...]"
+
+ip = sys.argv[1]
+cluster_a = sys.argv[2]
+specific_a = sys.argv[3]
+port = None
+srv_addrs = []
+
+ttl = "300"
+
+if len(sys.argv) > 5:
+    port = sys.argv[4]
+    srv_addrs = sys.argv[5:]
+
+ret = [{"rr":"A", "alias": cluster_a, "ttl": ttl,"addr": ip},
+       {"rr":"A", "alias": specific_a, "ttl": ttl,"addr": ip}]
+
+for a in srv_addrs:
+    ret.append({"rr": "SRV", "alias": a, "ttl": ttl,"priority": "1", "weight": "1", "port": port, "target": specific_a})
+
+print json.dumps(ret)

--- a/charms/precise/clearwater-sprout/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-sprout/hooks/programmable-multiple-relation-changed
@@ -6,7 +6,6 @@ id=$(cut -d/ -f2 <<< $JUJU_UNIT_NAME)
 ip=$(unit-get private-address)
 relation-set domain=$(config-get zone)
 DNS_JSON=$($CHARM_DIR/lib/generate_dns_records $ip sprout sprout-$id 5054 _sip._tcp.sprout)
-DNS_JSON="'$DNS_JSON'"
 relation-set resources="$DNS_JSON"
 
 # Update our DNS server

--- a/charms/precise/clearwater-sprout/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-sprout/hooks/programmable-multiple-relation-changed
@@ -7,7 +7,7 @@ ip=$(unit-get private-address)
 relation-set domain=$(config-get zone)
 DNS_JSON=$($CHARM_DIR/lib/generate_dns_records $ip sprout sprout-$id 5054 _sip._tcp.sprout)
 DNS_JSON="'$DNS_JSON'"
-relation-set resources=$DNS_JSON
+relation-set resources="$DNS_JSON"
 
 # Update our DNS server
 if [ "$(relation-get private-address)" != "" ]

--- a/charms/precise/clearwater-sprout/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-sprout/hooks/programmable-multiple-relation-changed
@@ -5,7 +5,8 @@ set -e
 id=$(cut -d/ -f2 <<< $JUJU_UNIT_NAME)
 ip=$(unit-get private-address)
 relation-set domain=$(config-get zone)
-DNS_JSON=`$CHARM_DIR/lib/generate_dns_records $ip sprout sprout-$id 5054 _sip._tcp.sprout`
+DNS_JSON=$($CHARM_DIR/lib/generate_dns_records $ip sprout sprout-$id 5054 _sip._tcp.sprout)
+DNS_JSON="'$DNS_JSON'"
 relation-set resources=$DNS_JSON
 
 # Update our DNS server

--- a/charms/precise/clearwater-sprout/hooks/programmable-multiple-relation-changed
+++ b/charms/precise/clearwater-sprout/hooks/programmable-multiple-relation-changed
@@ -2,14 +2,11 @@
 set -e
 
 # Set our DNS requirements
-TTL=300
 id=$(cut -d/ -f2 <<< $JUJU_UNIT_NAME)
 ip=$(unit-get private-address)
 relation-set domain=$(config-get zone)
-relation-set resources='sprout '$TTL' IN A '$ip'
-sprout '$TTL' IN NAPTR 1 1 "S" "SIP+D2T" "" _sip._tcp.sprout
-_sip._tcp.sprout '$TTL' IN SRV 0 0 5054 sprout-'$id'
-sprout-'$id' '$TTL' IN A '$ip
+DNS_JSON=`$CHARM_DIR/lib/generate_dns_records $ip sprout sprout-$id 5054 _sip._tcp.sprout`
+relation-set resources=$DNS_JSON
 
 # Update our DNS server
 if [ "$(relation-get private-address)" != "" ]

--- a/charms/precise/clearwater-sprout/lib/generate_dns_records
+++ b/charms/precise/clearwater-sprout/lib/generate_dns_records
@@ -1,0 +1,63 @@
+#!/usr/bin/python
+
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2015 Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+# This script generates a JSON-ified set of DNS records based on an IP, A
+# records and SRV records. These are suitable for the API to
+# https://github.com/chuckbutler/DNS-Charm.
+
+import sys
+import json
+
+if len(sys.argv) < 4:
+    print "Usage: generate_dns_records.py IP CLUSTER_A_RECORD SPECIFIC_A_RECORD [SRV_PORT SRV_ADDR...]"
+
+ip = sys.argv[1]
+cluster_a = sys.argv[2]
+specific_a = sys.argv[3]
+port = None
+srv_addrs = []
+
+ttl = "300"
+
+if len(sys.argv) > 5:
+    port = sys.argv[4]
+    srv_addrs = sys.argv[5:]
+
+ret = [{"rr":"A", "alias": cluster_a, "ttl": ttl,"addr": ip},
+       {"rr":"A", "alias": specific_a, "ttl": ttl,"addr": ip}]
+
+for a in srv_addrs:
+    ret.append({"rr": "SRV", "alias": a, "ttl": ttl,"priority": "1", "weight": "1", "port": port, "target": specific_a})
+
+print json.dumps(ret)


### PR DESCRIPTION
I'm not sure I should merge this yet - it doesn't look like a JSON-using DNS charm has been released - but it's good to have it ready.

(The latest code at https://github.com/chuckbutler/DNS-Charm has this support, but the charm at https://jujucharms.com/u/zoology/dns/ doesn't seem to.)

All the `generate_dns_records` files are identical.
