### PR TITLE
[Reviewer: Andy] Wait for the components to have restarted before reporting completion

### DIFF
--- a/charms/trusty/clearwater-aio-proxy/lib/reconfigure-aio
+++ b/charms/trusty/clearwater-aio-proxy/lib/reconfigure-aio
@@ -40,4 +40,16 @@ if [ "$home_domain" != "$old_home_domain" ] ; then
 
   # Restart all the processes.
   for X in /usr/share/clearwater/infrastructure/scripts/restart/* ; do $X ; done
+
+  # Kick monit to wake up and sleep for 10 seconds to make sure it has an accurate view of the system.
+  monit
+  sleep 10
+
+  # Now wait until all the processes are back up and running (or at least "Uptime failed", which
+  # means the process is running, just hasn't been running for very long).
+  while monit summary | grep _process | egrep -v "(Running|Uptime failed)" ; do
+    echo Some processes still not running - waiting...
+    sleep 2
+  done
+  echo All processes running - configuration complete!
 fi


### PR DESCRIPTION
Andy,

Please can you review this fix, which waits for components to have been restarted before reporting completion?  This means that the user can immediately perform other actions (e.g. creating users).

Matt
